### PR TITLE
chore: ignore dartdoc generated api files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,22 @@
+# Files and directories created by pub
 .packages
 .pub/
+build/
 packages
 pubspec.lock
+
+# Files created by dart2js
+*.dart.js
+*.part.js
+*.js.deps
+*.js.map
+*.info.json
+
+# Directory created by dartdoc
+doc/api/
+
+# JetBrains IDEs
+.idea/
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
This `.gitignore` is essentially the default stagehand file.

cc @kwalrath 