### PR TITLE
Format comments based on the dart style guide

### DIFF
--- a/lib/src/common/common_directives.dart
+++ b/lib/src/common/common_directives.dart
@@ -12,48 +12,52 @@ import "forms.dart" show FORM_DIRECTIVES;
 ///
 /// Instead of writing:
 ///
-///     import 'package:angular2/common.dart'
-///         show
-///             NgClass,
-///             NgIf,
-///             NgFor,
-///             NgSwitch,
-///             NgSwitchWhen,
-///             NgSwitchDefault,
-///             NgModel,
-///             NgForm;
-///     import 'my_directives.dart' show OtherDirective;
+/// ```dart
+/// import 'package:angular2/common.dart'
+///     show
+///         NgClass,
+///         NgIf,
+///         NgFor,
+///         NgSwitch,
+///         NgSwitchWhen,
+///         NgSwitchDefault,
+///         NgModel,
+///         NgForm;
+/// import 'my_directives.dart' show OtherDirective;
 ///
-///     @Component(
-///         selector: 'my-component',
-///         templateUrl: 'my_component.html',
-///         directives: const [
-///           NgClass,
-///           NgIf,
-///           NgFor,
-///           NgSwitch,
-///           NgSwitchWhen,
-///           NgSwitchDefault,
-///           NgModel,
-///           NgForm,
-///           OtherDirective
-///         ])
-///     class MyComponent {
-///       ...
-///     }
+/// @Component(
+///     selector: 'my-component',
+///     templateUrl: 'my_component.html',
+///     directives: const [
+///       NgClass,
+///       NgIf,
+///       NgFor,
+///       NgSwitch,
+///       NgSwitchWhen,
+///       NgSwitchDefault,
+///       NgModel,
+///       NgForm,
+///       OtherDirective
+///     ])
+/// class MyComponent {
+///   ...
+/// }
+/// ```
 ///
 /// One could import all the core directives at once:
 ///
-///     import 'angular2/common.dart' show COMMON_DIRECTIVES;
-///     import 'my_directives.dart' show OtherDirective;
+/// ```dart
+/// import 'angular2/common.dart' show COMMON_DIRECTIVES;
+/// import 'my_directives.dart' show OtherDirective;
 ///
-///     @Component(
-///         selector: 'my-component',
-///         templateUrl: 'my_component.html',
-///         directives: const [COMMON_DIRECTIVES, OtherDirective])
-///     class MyComponent {
-///       ...
-///     }
+/// @Component(
+///     selector: 'my-component',
+///     templateUrl: 'my_component.html',
+///     directives: const [COMMON_DIRECTIVES, OtherDirective])
+/// class MyComponent {
+///   ...
+/// }
+/// ```
 const List<List<Type>> COMMON_DIRECTIVES = const [
   CORE_DIRECTIVES,
   FORM_DIRECTIVES

--- a/lib/src/common/common_directives.dart
+++ b/lib/src/common/common_directives.dart
@@ -1,49 +1,59 @@
 import "directives.dart" show CORE_DIRECTIVES;
 import "forms.dart" show FORM_DIRECTIVES;
 
-/**
- * A collection of Angular core directives that are likely to be used in each and every Angular
- * application. This includes core directives (e.g., NgIf and NgFor), and forms directives (e.g.,
- * NgModel).
- *
- * This collection can be used to quickly enumerate all the built-in directives in the `directives`
- * property of the `@Component` decorator.
- *
- * ### Example
- *
- * Instead of writing:
- *
- * ```typescript
- * import {NgClass, NgIf, NgFor, NgSwitch, NgSwitchWhen, NgSwitchDefault, NgModel, NgForm} from
- * 'angular2/common';
- * import {OtherDirective} from './myDirectives';
- *
- * @Component({
- *   selector: 'my-component',
- *   templateUrl: 'myComponent.html',
- *   directives: [NgClass, NgIf, NgFor, NgSwitch, NgSwitchWhen, NgSwitchDefault, NgModel, NgForm,
- * OtherDirective]
- * })
- * export class MyComponent {
- *   ...
- * }
- * ```
- * one could import all the common directives at once:
- *
- * ```typescript
- * import {COMMON_DIRECTIVES} from 'angular2/common';
- * import {OtherDirective} from './myDirectives';
- *
- * @Component({
- *   selector: 'my-component',
- *   templateUrl: 'myComponent.html',
- *   directives: [COMMON_DIRECTIVES, OtherDirective]
- * })
- * export class MyComponent {
- *   ...
- * }
- * ```
- */
+/// A collection of Angular core directives that are likely to be used in each
+/// and every Angular application. This includes core directives
+/// (e.g., NgIf and NgFor), and forms directives (e.g., NgModel).
+///
+/// This collection can be used to quickly enumerate all the built-in directives
+/// in the `directives` property of the `@Component` annotation.
+///
+/// ### Example
+///
+/// Instead of writing:
+///
+///     import 'package:angular2/common.dart'
+///         show
+///             NgClass,
+///             NgIf,
+///             NgFor,
+///             NgSwitch,
+///             NgSwitchWhen,
+///             NgSwitchDefault,
+///             NgModel,
+///             NgForm;
+///     import 'my_directives.dart' show OtherDirective;
+///
+///     @Component(
+///         selector: 'my-component',
+///         templateUrl: 'my_component.html',
+///         directives: const [
+///           NgClass,
+///           NgIf,
+///           NgFor,
+///           NgSwitch,
+///           NgSwitchWhen,
+///           NgSwitchDefault,
+///           NgModel,
+///           NgForm,
+///           OtherDirective
+///         ])
+///     class MyComponent {
+///       ...
+///     }
+///
+/// One could import all the core directives at once:
+///
+///     import 'angular2/common.dart' show COMMON_DIRECTIVES;
+///     import 'my_directives.dart' show OtherDirective;
+///
+///     @Component(
+///         selector: 'my-component',
+///         templateUrl: 'my_component.html',
+///         directives: const [COMMON_DIRECTIVES, OtherDirective])
+///     class MyComponent {
+///       ...
+///     }
 const List<List<Type>> COMMON_DIRECTIVES = const [
   CORE_DIRECTIVES,
   FORM_DIRECTIVES

--- a/lib/src/common/directives.dart
+++ b/lib/src/common/directives.dart
@@ -1,8 +1,4 @@
-/**
- * 
- * 
- * Common directives shipped with Angular.
- */
+// Common directives shipped with Angular.
 
 export "directives/core_directives.dart" show CORE_DIRECTIVES;
 export "directives/ng_class.dart" show NgClass;

--- a/lib/src/common/directives/core_directives.dart
+++ b/lib/src/common/directives/core_directives.dart
@@ -16,44 +16,48 @@ import "ng_template_outlet.dart" show NgTemplateOutlet;
 ///
 /// Instead of writing:
 ///
-///     import 'package:angular2/common.dart'
-///         show
-///             NgClass,
-///             NgIf,
-///             NgFor,
-///             NgSwitch,
-///             NgSwitchWhen,
-///             NgSwitchDefault;
-///     import 'my_directives.dart' show OtherDirective;
+/// ```dart
+/// import 'package:angular2/common.dart'
+///     show
+///         NgClass,
+///         NgIf,
+///         NgFor,
+///         NgSwitch,
+///         NgSwitchWhen,
+///         NgSwitchDefault;
+/// import 'my_directives.dart' show OtherDirective;
 ///
-///     @Component(
-///         selector: 'my-component',
-///         templateUrl: 'my_component.html',
-///         directives: const [
-///           NgClass,
-///           NgIf,
-///           NgFor,
-///           NgSwitch,
-///           NgSwitchWhen,
-///           NgSwitchDefault,
-///           OtherDirective
-///         ])
-///     class MyComponent {
-///       ...
-///     }
+/// @Component(
+///     selector: 'my-component',
+///     templateUrl: 'my_component.html',
+///     directives: const [
+///       NgClass,
+///       NgIf,
+///       NgFor,
+///       NgSwitch,
+///       NgSwitchWhen,
+///       NgSwitchDefault,
+///       OtherDirective
+///     ])
+/// class MyComponent {
+///   ...
+/// }
+/// ```
 ///
 /// One could import all the core directives at once:
 ///
-///     import 'angular2/common.dart' show CORE_DIRECTIVES;
-///     import 'my_directives.dart' show OtherDirective;
+/// ```dart
+/// import 'angular2/common.dart' show CORE_DIRECTIVES;
+/// import 'my_directives.dart' show OtherDirective;
 ///
-///     @Component(
-///         selector: 'my-component',
-///         templateUrl: 'my_component.html',
-///         directives: const [CORE_DIRECTIVES, OtherDirective])
-///     class MyComponent {
-///       ...
-///     }
+/// @Component(
+///     selector: 'my-component',
+///     templateUrl: 'my_component.html',
+///     directives: const [CORE_DIRECTIVES, OtherDirective])
+/// class MyComponent {
+///   ...
+/// }
+/// ```
 const List<Type> CORE_DIRECTIVES = const [
   NgClass,
   NgFor,

--- a/lib/src/common/directives/core_directives.dart
+++ b/lib/src/common/directives/core_directives.dart
@@ -6,46 +6,54 @@ import "ng_style.dart" show NgStyle;
 import "ng_switch.dart" show NgSwitch, NgSwitchWhen, NgSwitchDefault;
 import "ng_template_outlet.dart" show NgTemplateOutlet;
 
-/**
- * A collection of Angular core directives that are likely to be used in each and every Angular
- * application.
- *
- * This collection can be used to quickly enumerate all the built-in directives in the `directives`
- * property of the `@Component` annotation.
- *
- * ### Example ([live demo](http://plnkr.co/edit/yakGwpCdUkg0qfzX5m8g?p=preview))
- *
- * Instead of writing:
- *
- * ```typescript
- * import {NgClass, NgIf, NgFor, NgSwitch, NgSwitchWhen, NgSwitchDefault} from 'angular2/common';
- * import {OtherDirective} from './myDirectives';
- *
- * @Component({
- *   selector: 'my-component',
- *   templateUrl: 'myComponent.html',
- *   directives: [NgClass, NgIf, NgFor, NgSwitch, NgSwitchWhen, NgSwitchDefault, OtherDirective]
- * })
- * export class MyComponent {
- *   ...
- * }
- * ```
- * one could import all the core directives at once:
- *
- * ```typescript
- * import {CORE_DIRECTIVES} from 'angular2/common';
- * import {OtherDirective} from './myDirectives';
- *
- * @Component({
- *   selector: 'my-component',
- *   templateUrl: 'myComponent.html',
- *   directives: [CORE_DIRECTIVES, OtherDirective]
- * })
- * export class MyComponent {
- *   ...
- * }
- * ```
- */
+/// A collection of Angular core directives that are likely to be used in each
+/// and every Angular application.
+///
+/// This collection can be used to quickly enumerate all the built-in directives
+/// in the `directives` property of the `@Component` annotation.
+///
+/// ### Example
+///
+/// Instead of writing:
+///
+///     import 'package:angular2/common.dart'
+///         show
+///             NgClass,
+///             NgIf,
+///             NgFor,
+///             NgSwitch,
+///             NgSwitchWhen,
+///             NgSwitchDefault;
+///     import 'my_directives.dart' show OtherDirective;
+///
+///     @Component(
+///         selector: 'my-component',
+///         templateUrl: 'my_component.html',
+///         directives: const [
+///           NgClass,
+///           NgIf,
+///           NgFor,
+///           NgSwitch,
+///           NgSwitchWhen,
+///           NgSwitchDefault,
+///           OtherDirective
+///         ])
+///     class MyComponent {
+///       ...
+///     }
+///
+/// One could import all the core directives at once:
+///
+///     import 'angular2/common.dart' show CORE_DIRECTIVES;
+///     import 'my_directives.dart' show OtherDirective;
+///
+///     @Component(
+///         selector: 'my-component',
+///         templateUrl: 'my_component.html',
+///         directives: const [CORE_DIRECTIVES, OtherDirective])
+///     class MyComponent {
+///       ...
+///     }
 const List<Type> CORE_DIRECTIVES = const [
   NgClass,
   NgFor,

--- a/lib/src/common/directives/ng_class.dart
+++ b/lib/src/common/directives/ng_class.dart
@@ -16,65 +16,63 @@ import "package:angular2/src/facade/collection.dart"
 import "package:angular2/src/facade/lang.dart"
     show isPresent, isString, isArray;
 
-/**
- * The `NgClass` directive conditionally adds and removes CSS classes on an HTML element based on
- * an expression's evaluation result.
- *
- * The result of an expression evaluation is interpreted differently depending on type of
- * the expression evaluation result:
- * - `string` - all the CSS classes listed in a string (space delimited) are added
- * - `Array` - all the CSS classes (Array elements) are added
- * - `Object` - each key corresponds to a CSS class name while values are interpreted as expressions
- * evaluating to `Boolean`. If a given expression evaluates to `true` a corresponding CSS class
- * is added - otherwise it is removed.
- *
- * While the `NgClass` directive can interpret expressions evaluating to `string`, `Array`
- * or `Object`, the `Object`-based version is the most often used and has an advantage of keeping
- * all the CSS class names in a template.
- *
- * ### Example ([live demo](http://plnkr.co/edit/a4YdtmWywhJ33uqfpPPn?p=preview)):
- *
- * ```
- * import {Component} from 'angular2/core';
- * import {NgClass} from 'angular2/common';
- *
- * @Component({
- *   selector: 'toggle-button',
- *   inputs: ['isDisabled'],
- *   template: `
- *      <div class="button" [ngClass]="{active: isOn, disabled: isDisabled}"
- *          (click)="toggle(!isOn)">
- *          Click me!
- *      </div>`,
- *   styles: [`
- *     .button {
- *       width: 120px;
- *       border: medium solid black;
- *     }
- *
- *     .active {
- *       background-color: red;
- *    }
- *
- *     .disabled {
- *       color: gray;
- *       border: medium solid gray;
- *     }
- *   `]
- *   directives: [NgClass]
- * })
- * class ToggleButton {
- *   isOn = false;
- *   isDisabled = false;
- *
- *   toggle(newState) {
- *     if (!this.isDisabled) {
- *       this.isOn = newState;
- *     }
- *   }
- * }
- * ```
- */
+/// The `NgClass` directive conditionally adds and removes CSS classes on an
+/// HTML element based on an expression's evaluation result.
+///
+/// The result of an expression evaluation is interpreted differently depending
+/// on type of the expression evaluation result:
+/// - `String` - all the CSS classes listed in a string (space delimited) are
+/// added
+/// - `List` - all the CSS classes (List elements) are added
+/// - `Map` - each key corresponds to a CSS class name while values are
+/// interpreted as expressions evaluating to `Boolean`. If a given expression
+/// evaluates to `true` a corresponding CSS class is added - otherwise it is
+/// removed.
+///
+/// While the `NgClass` directive can interpret expressions evaluating to
+/// `String`, `List` or `Map`, the `Map`-based version is the most often used
+/// and has an advantage of keeping all the CSS class names in a template.
+///
+/// ### Example:
+///
+///     import 'angular2/core.dart' show Component;
+///     import 'angular2/common.dart' show NgClass;
+///
+///     @Component(
+///       selector: 'toggle-button',
+///       inputs: const ['isDisabled'],
+///       template: '''
+///          <div class="button" [ngClass]="{active: isOn, disabled: isDisabled}"
+///              (click)="toggle(!isOn)">
+///              Click me!
+///          </div>''',
+///       styles: const ['''
+///         .button {
+///           width: 120px;
+///           border: medium solid black;
+///         }
+///
+///         .active {
+///           background-color: red;
+///        }
+///
+///         .disabled {
+///           color: gray;
+///           border: medium solid gray;
+///         }
+///       ''']
+///       directives: const [NgClass]
+///     )
+///     class ToggleButton {
+///       bool isOn = false;
+///       bool isDisabled = false;
+///
+///       void toggle(bool newState) {
+///         if (!isDisabled) {
+///           isOn = newState;
+///         }
+///       }
+///     }
 @Directive(
     selector: "[ngClass]",
     inputs: const ["rawClass: ngClass", "initialClasses: class"])

--- a/lib/src/common/directives/ng_class.dart
+++ b/lib/src/common/directives/ng_class.dart
@@ -35,44 +35,46 @@ import "package:angular2/src/facade/lang.dart"
 ///
 /// ### Example:
 ///
-///     import 'angular2/core.dart' show Component;
-///     import 'angular2/common.dart' show NgClass;
+/// ```dart
+/// import 'angular2/core.dart' show Component;
+/// import 'angular2/common.dart' show NgClass;
 ///
-///     @Component(
-///       selector: 'toggle-button',
-///       inputs: const ['isDisabled'],
-///       template: '''
-///          <div class="button" [ngClass]="{active: isOn, disabled: isDisabled}"
-///              (click)="toggle(!isOn)">
-///              Click me!
-///          </div>''',
-///       styles: const ['''
-///         .button {
-///           width: 120px;
-///           border: medium solid black;
-///         }
-///
-///         .active {
-///           background-color: red;
-///        }
-///
-///         .disabled {
-///           color: gray;
-///           border: medium solid gray;
-///         }
-///       ''']
-///       directives: const [NgClass]
-///     )
-///     class ToggleButton {
-///       bool isOn = false;
-///       bool isDisabled = false;
-///
-///       void toggle(bool newState) {
-///         if (!isDisabled) {
-///           isOn = newState;
-///         }
-///       }
+/// @Component(
+///   selector: 'toggle-button',
+///   inputs: const ['isDisabled'],
+///   template: '''
+///      <div class="button" [ngClass]="{active: isOn, disabled: isDisabled}"
+///          (click)="toggle(!isOn)">
+///          Click me!
+///      </div>''',
+///   styles: const ['''
+///     .button {
+///       width: 120px;
+///       border: medium solid black;
 ///     }
+///
+///     .active {
+///       background-color: red;
+///    }
+///
+///     .disabled {
+///       color: gray;
+///       border: medium solid gray;
+///     }
+///   ''']
+///   directives: const [NgClass]
+/// )
+/// class ToggleButton {
+///   bool isOn = false;
+///   bool isDisabled = false;
+///
+///   void toggle(bool newState) {
+///     if (!isDisabled) {
+///       isOn = newState;
+///     }
+///   }
+/// }
+/// ```
 @Directive(
     selector: "[ngClass]",
     inputs: const ["rawClass: ngClass", "initialClasses: class"])

--- a/lib/src/common/directives/ng_for.dart
+++ b/lib/src/common/directives/ng_for.dart
@@ -15,57 +15,60 @@ import "../../core/change_detection/differs/default_iterable_differ.dart"
     show DefaultIterableDiffer, CollectionChangeRecord;
 import "../../facade/exceptions.dart" show BaseException;
 
-/**
- * The `NgFor` directive instantiates a template once per item from an iterable. The context for
- * each instantiated template inherits from the outer context with the given loop variable set
- * to the current item from the iterable.
- *
- * ### Local Variables
- *
- * `NgFor` provides several exported values that can be aliased to local variables:
- *
- * * `index` will be set to the current loop iteration for each template context.
- * * `first` will be set to a boolean value indicating whether the item is the first one in the
- *   iteration.
- * * `last` will be set to a boolean value indicating whether the item is the last one in the
- *   iteration.
- * * `even` will be set to a boolean value indicating whether this item has an even index.
- * * `odd` will be set to a boolean value indicating whether this item has an odd index.
- *
- * ### Change Propagation
- *
- * When the contents of the iterator changes, `NgFor` makes the corresponding changes to the DOM:
- *
- * * When an item is added, a new instance of the template is added to the DOM.
- * * When an item is removed, its template instance is removed from the DOM.
- * * When items are reordered, their respective templates are reordered in the DOM.
- * * Otherwise, the DOM element for that item will remain the same.
- *
- * Angular uses object identity to track insertions and deletions within the iterator and reproduce
- * those changes in the DOM. This has important implications for animations and any stateful
- * controls
- * (such as `<input>` elements which accept user input) that are present. Inserted rows can be
- * animated in, deleted rows can be animated out, and unchanged rows retain any unsaved state such
- * as user input.
- *
- * It is possible for the identities of elements in the iterator to change while the data does not.
- * This can happen, for example, if the iterator produced from an RPC to the server, and that
- * RPC is re-run. Even if the data hasn't changed, the second response will produce objects with
- * different identities, and Angular will tear down the entire DOM and rebuild it (as if all old
- * elements were deleted and all new elements inserted). This is an expensive operation and should
- * be avoided if possible.
- *
- * ### Syntax
- *
- * - `<li *ngFor="let item of items; #i = index">...</li>`
- * - `<li template="ngFor #item of items; #i = index">...</li>`
- * - `<template ngFor #item [ngForOf]="items" #i="index"><li>...</li></template>`
- *
- * ### Example
- *
- * See a [live demo](http://plnkr.co/edit/KVuXxDp0qinGDyo307QW?p=preview) for a more detailed
- * example.
- */
+/// The `NgFor` directive instantiates a template once per item from an
+/// iterable. The context for each instantiated template inherits from the outer
+/// context with the given loop variable set to the current item from the
+/// iterable.
+///
+/// ### Local Variables
+///
+/// `NgFor` provides several exported values that can be aliased to local
+/// variables:
+///
+/// * `index` will be set to the current loop iteration for each template
+/// context.
+/// * `first` will be set to a boolean value indicating whether the item is the
+/// first one in the
+///   iteration.
+/// * `last` will be set to a boolean value indicating whether the item is the
+/// last one in the
+///   iteration.
+/// * `even` will be set to a boolean value indicating whether this item has an
+/// even index.
+/// * `odd` will be set to a boolean value indicating whether this item has an
+/// odd index.
+///
+/// ### Change Propagation
+///
+/// When the contents of the iterator changes, `NgFor` makes the corresponding
+/// changes to the DOM:
+///
+/// * When an item is added, a new instance of the template is added to the DOM.
+/// * When an item is removed, its template instance is removed from the DOM.
+/// * When items are reordered, their respective templates are reordered in the
+/// DOM.
+/// * Otherwise, the DOM element for that item will remain the same.
+///
+/// Angular uses object identity to track insertions and deletions within the
+/// iterator and reproduce those changes in the DOM. This has important
+/// implications for animations and any stateful controls
+/// (such as `<input>` elements which accept user input) that are present.
+/// Inserted rows can be animated in, deleted rows can be animated out, and
+/// unchanged rows retain any unsaved state such as user input.
+///
+/// It is possible for the identities of elements in the iterator to change
+/// while the data does not. This can happen, for example, if the iterator
+/// produced from an RPC to the server, and that RPC is re-run. Even if the data
+/// hasn't changed, the second response will produce objects with different
+/// identities, and Angular will tear down the entire DOM and rebuild it (as if
+/// all old elements were deleted and all new elements inserted). This is an
+/// expensive operation and should be avoided if possible.
+///
+/// ### Syntax
+///
+/// - `<li *ngFor="let item of items; #i = index">...</li>`
+/// - `<li template="ngFor #item of items; #i = index">...</li>`
+/// - `<template ngFor #item [ngForOf]="items" #i="index"><li>...</li></template>`
 @Directive(
     selector: "[ngFor][ngForOf]",
     inputs: const ["ngForTrackBy", "ngForOf", "ngForTemplate"])
@@ -74,9 +77,7 @@ class NgFor implements DoCheck {
   TemplateRef _templateRef;
   IterableDiffers _iterableDiffers;
   ChangeDetectorRef _cdr;
-  /** @internal */
   dynamic _ngForOf;
-  /** @internal */
   TrackByFn _ngForTrackBy;
   IterableDiffer _differ;
   NgFor(this._viewContainer, this._templateRef, this._iterableDiffers,

--- a/lib/src/common/directives/ng_plural.dart
+++ b/lib/src/common/directives/ng_plural.dart
@@ -19,65 +19,60 @@ abstract class NgLocalization {
   String getPluralCategory(dynamic value);
 }
 
-/**
- * `ngPlural` is an i18n directive that displays DOM sub-trees that match the switch expression
- * value, or failing that, DOM sub-trees that match the switch expression's pluralization category.
- *
- * To use this directive, you must provide an extension of `NgLocalization` that maps values to
- * category names. You then define a container element that sets the `[ngPlural]` attribute to a
- * switch expression.
- *    - Inner elements defined with an `[ngPluralCase]` attribute will display based on their
- * expression.
- *    - If `[ngPluralCase]` is set to a value starting with `=`, it will only display if the value
- * matches the switch expression exactly.
- *    - Otherwise, the view will be treated as a "category match", and will only display if exact
- * value matches aren't found and the value maps to its category using the `getPluralCategory`
- * function provided.
- *
- * If no matching views are found for a switch expression, inner elements marked
- * `[ngPluralCase]="other"` will be displayed.
- *
- * ```typescript
- * class MyLocalization extends NgLocalization {
- *    getPluralCategory(value: any) {
- *       if(value < 5) {
- *          return 'few';
- *       }
- *    }
- * }
- *
- * @Component({
- *    selector: 'app',
- *    providers: [provide(NgLocalization, {useClass: MyLocalization})]
- * })
- * @View({
- *   template: `
- *     <p>Value = {{value}}</p>
- *     <button (click)="inc()">Increment</button>
- *
- *     <div [ngPlural]="value">
- *       <template ngPluralCase="=0">there is nothing</template>
- *       <template ngPluralCase="=1">there is one</template>
- *       <template ngPluralCase="few">there are a few</template>
- *       <template ngPluralCase="other">there is some number</template>
- *     </div>
- *   `,
- *   directives: [NgPlural, NgPluralCase]
- * })
- * export class App {
- *   value = 'init';
- *
- *   inc() {
- *     this.value = this.value === 'init' ? 0 : this.value + 1;
- *   }
- * }
- *
- * ```
- */
+/// `ngPlural` is an i18n directive that displays DOM sub-trees that match the
+/// switch expression value, or failing that, DOM sub-trees that match the
+/// switch expression's pluralization category.
+///
+/// To use this directive, you must provide an extension of `NgLocalization`
+/// that maps values to category names. You then define a container element that
+/// sets the `[ngPlural]` attribute to a switch expression.
+///    - Inner elements defined with an `[ngPluralCase]` attribute will display
+///    based on their expression.
+///    - If `[ngPluralCase]` is set to a value starting with `=`, it will only
+///    display if the value matches the switch expression exactly.
+///    - Otherwise, the view will be treated as a "category match", and will
+///    only display if exact value matches aren't found and the value maps to
+///    its category using the `getPluralCategory` function provided.
+///
+/// If no matching views are found for a switch expression, inner elements
+/// marked `[ngPluralCase]="other"` will be displayed.
+///
+///     class MyLocalization extends NgLocalization {
+///        getPluralCategory(value: any) {
+///           if(value < 5) {
+///              return 'few';
+///           }
+///        }
+///     }
+///
+///     @Component(
+///        selector: 'app',
+///        providers: const [provide(NgLocalization, {useClass: MyLocalization})]
+///     )
+///     @View(
+///       template: '''
+///         <p>Value = {{value}}</p>
+///         <button (click)="inc()">Increment</button>
+///
+///         <div [ngPlural]="value">
+///           <template ngPluralCase="=0">there is nothing</template>
+///           <template ngPluralCase="=1">there is one</template>
+///           <template ngPluralCase="few">there are a few</template>
+///           <template ngPluralCase="other">there is some number</template>
+///         </div>
+///       ''',
+///       directives: const [NgPlural, NgPluralCase]
+///     )
+///     class App {
+///       dynamic value = 'init';
+///
+///       void inc() {
+///         value = value === 'init' ? 0 : value + 1;
+///       }
+///     }
 @Directive(selector: "[ngPluralCase]")
 class NgPluralCase {
   String value;
-  /** @internal */
   SwitchView _view;
   NgPluralCase(@Attribute("ngPluralCase") this.value, TemplateRef template,
       ViewContainerRef viewContainer) {
@@ -107,7 +102,6 @@ class NgPlural implements AfterContentInit {
     this._updateView();
   }
 
-  /** @internal */
   void _updateView() {
     this._clearViews();
     SwitchView view = this._caseViews[this._switchValue];
@@ -115,19 +109,16 @@ class NgPlural implements AfterContentInit {
     this._activateView(view);
   }
 
-  /** @internal */
   _clearViews() {
     if (isPresent(this._activeView)) this._activeView.destroy();
   }
 
-  /** @internal */
   _activateView(SwitchView view) {
     if (!isPresent(view)) return;
     this._activeView = view;
     this._activeView.create();
   }
 
-  /** @internal */
   SwitchView _getCategoryView(num value) {
     String category = this._localization.getPluralCategory(value);
     SwitchView categoryView = this._caseViews[category];
@@ -136,19 +127,16 @@ class NgPlural implements AfterContentInit {
         : this._caseViews[_CATEGORY_DEFAULT];
   }
 
-  /** @internal */
   bool _isValueView(NgPluralCase pluralCase) {
     return identical(pluralCase.value[0], "=");
   }
 
-  /** @internal */
   dynamic _formatValue(NgPluralCase pluralCase) {
     return this._isValueView(pluralCase)
         ? this._stripValue(pluralCase.value)
         : pluralCase.value;
   }
 
-  /** @internal */
   num _stripValue(String value) {
     return NumberWrapper.parseInt(value.substring(1), 10);
   }

--- a/lib/src/common/directives/ng_plural.dart
+++ b/lib/src/common/directives/ng_plural.dart
@@ -37,39 +37,41 @@ abstract class NgLocalization {
 /// If no matching views are found for a switch expression, inner elements
 /// marked `[ngPluralCase]="other"` will be displayed.
 ///
-///     class MyLocalization extends NgLocalization {
-///        getPluralCategory(value: any) {
-///           if(value < 5) {
-///              return 'few';
-///           }
-///        }
-///     }
-///
-///     @Component(
-///        selector: 'app',
-///        providers: const [provide(NgLocalization, {useClass: MyLocalization})]
-///     )
-///     @View(
-///       template: '''
-///         <p>Value = {{value}}</p>
-///         <button (click)="inc()">Increment</button>
-///
-///         <div [ngPlural]="value">
-///           <template ngPluralCase="=0">there is nothing</template>
-///           <template ngPluralCase="=1">there is one</template>
-///           <template ngPluralCase="few">there are a few</template>
-///           <template ngPluralCase="other">there is some number</template>
-///         </div>
-///       ''',
-///       directives: const [NgPlural, NgPluralCase]
-///     )
-///     class App {
-///       dynamic value = 'init';
-///
-///       void inc() {
-///         value = value === 'init' ? 0 : value + 1;
+/// ```dart
+/// class MyLocalization extends NgLocalization {
+///    getPluralCategory(value: any) {
+///       if(value < 5) {
+///          return 'few';
 ///       }
-///     }
+///    }
+/// }
+///
+/// @Component(
+///    selector: 'app',
+///    providers: const [provide(NgLocalization, {useClass: MyLocalization})]
+/// )
+/// @View(
+///   template: '''
+///     <p>Value = {{value}}</p>
+///     <button (click)="inc()">Increment</button>
+///
+///     <div [ngPlural]="value">
+///       <template ngPluralCase="=0">there is nothing</template>
+///       <template ngPluralCase="=1">there is one</template>
+///       <template ngPluralCase="few">there are a few</template>
+///       <template ngPluralCase="other">there is some number</template>
+///     </div>
+///   ''',
+///   directives: const [NgPlural, NgPluralCase]
+/// )
+/// class App {
+///   dynamic value = 'init';
+///
+///   void inc() {
+///     value = value === 'init' ? 0 : value + 1;
+///   }
+/// }
+/// ```
 @Directive(selector: "[ngPluralCase]")
 class NgPluralCase {
   String value;

--- a/lib/src/common/directives/ng_style.dart
+++ b/lib/src/common/directives/ng_style.dart
@@ -27,37 +27,39 @@ import "../../core/change_detection/differs/default_keyvalue_differ.dart"
 ///
 /// ### Example:
 ///
-///     import 'angular2/core.dart' Component;
-///     import 'angular2/common.dart' NgStyle;
+/// ```dart
+/// import 'angular2/core.dart' Component;
+/// import 'angular2/common.dart' NgStyle;
 ///
-///     @Component(
-///      selector: 'ngStyle-example',
-///      template: '''
-///        <h1 [ngStyle]="{'font-style': style, 'font-size': size, 'font-weight': weight}">
-///          Change style of this text!
-///        </h1>
+/// @Component(
+///  selector: 'ngStyle-example',
+///  template: '''
+///    <h1 [ngStyle]="{'font-style': style, 'font-size': size, 'font-weight': weight}">
+///      Change style of this text!
+///    </h1>
 ///
-///        <hr>
+///    <hr>
 ///
-///        <label>Italic: <input type="checkbox" (change)="changeStyle($event)"></label>
-///        <label>Bold: <input type="checkbox" (change)="changeWeight($event)"></label>
-///        <label>Size: <input type="text" [value]="size" (change)="size = $event.target.value"></label>
-///      ''',
-///      directives: const [NgStyle]
-///     )
-///     class NgStyleExample {
-///        String style = 'normal';
-///        String weight = 'normal';
-///        String size = '20px';
+///    <label>Italic: <input type="checkbox" (change)="changeStyle($event)"></label>
+///    <label>Bold: <input type="checkbox" (change)="changeWeight($event)"></label>
+///    <label>Size: <input type="text" [value]="size" (change)="size = $event.target.value"></label>
+///  ''',
+///  directives: const [NgStyle]
+/// )
+/// class NgStyleExample {
+///    String style = 'normal';
+///    String weight = 'normal';
+///    String size = '20px';
 ///
-///        void changeStyle(dynamic event) {
-///          style = event.target.checked ? 'italic' : 'normal';
-///        }
+///    void changeStyle(dynamic event) {
+///      style = event.target.checked ? 'italic' : 'normal';
+///    }
 ///
-///        void changeWeight(dynamic event) {
-///          weight = event.target.checked ? 'bold' : 'normal';
-///        }
-///     }
+///    void changeWeight(dynamic event) {
+///      weight = event.target.checked ? 'bold' : 'normal';
+///    }
+/// }
+/// ```
 ///
 /// In this example the `font-style`, `font-size` and `font-weight` styles will
 /// be updated based on the `style` property's value changes.

--- a/lib/src/common/directives/ng_style.dart
+++ b/lib/src/common/directives/ng_style.dart
@@ -11,65 +11,62 @@ import "package:angular2/src/facade/lang.dart" show isPresent, isBlank;
 import "../../core/change_detection/differs/default_keyvalue_differ.dart"
     show KeyValueChangeRecord;
 
-/**
- * The `NgStyle` directive changes styles based on a result of expression evaluation.
- *
- * An expression assigned to the `ngStyle` property must evaluate to an object and the
- * corresponding element styles are updated based on changes to this object. Style names to update
- * are taken from the object's keys, and values - from the corresponding object's values.
- *
- * ### Syntax
- *
- * - `<div [ngStyle]="{'font-style': style}"></div>`
- * - `<div [ngStyle]="styleExp"></div>` - here the `styleExp` must evaluate to an object
- *
- * ### Example ([live demo](http://plnkr.co/edit/YamGS6GkUh9GqWNQhCyM?p=preview)):
- *
- * ```
- * import {Component} from 'angular2/core';
- * import {NgStyle} from 'angular2/common';
- *
- * @Component({
- *  selector: 'ngStyle-example',
- *  template: `
- *    <h1 [ngStyle]="{'font-style': style, 'font-size': size, 'font-weight': weight}">
- *      Change style of this text!
- *    </h1>
- *
- *    <hr>
- *
- *    <label>Italic: <input type="checkbox" (change)="changeStyle($event)"></label>
- *    <label>Bold: <input type="checkbox" (change)="changeWeight($event)"></label>
- *    <label>Size: <input type="text" [value]="size" (change)="size = $event.target.value"></label>
- *  `,
- *  directives: [NgStyle]
- * })
- * export class NgStyleExample {
- *    style = 'normal';
- *    weight = 'normal';
- *    size = '20px';
- *
- *    changeStyle($event: any) {
- *      this.style = $event.target.checked ? 'italic' : 'normal';
- *    }
- *
- *    changeWeight($event: any) {
- *      this.weight = $event.target.checked ? 'bold' : 'normal';
- *    }
- * }
- * ```
- *
- * In this example the `font-style`, `font-size` and `font-weight` styles will be updated
- * based on the `style` property's value changes.
- */
+/// The `NgStyle` directive changes styles based on a result of expression
+/// evaluation.
+///
+/// An expression assigned to the `ngStyle` property must evaluate to an object
+/// and the corresponding element styles are updated based on changes to this
+/// object. Style names to update are taken from the object's keys, and values
+/// - from the corresponding object's values.
+///
+/// ### Syntax
+///
+/// - `<div [ngStyle]="{'font-style': style}"></div>`
+/// - `<div [ngStyle]="styleExp"></div>` - here the `styleExp` must evaluate to
+/// an object
+///
+/// ### Example:
+///
+///     import 'angular2/core.dart' Component;
+///     import 'angular2/common.dart' NgStyle;
+///
+///     @Component(
+///      selector: 'ngStyle-example',
+///      template: '''
+///        <h1 [ngStyle]="{'font-style': style, 'font-size': size, 'font-weight': weight}">
+///          Change style of this text!
+///        </h1>
+///
+///        <hr>
+///
+///        <label>Italic: <input type="checkbox" (change)="changeStyle($event)"></label>
+///        <label>Bold: <input type="checkbox" (change)="changeWeight($event)"></label>
+///        <label>Size: <input type="text" [value]="size" (change)="size = $event.target.value"></label>
+///      ''',
+///      directives: const [NgStyle]
+///     )
+///     class NgStyleExample {
+///        String style = 'normal';
+///        String weight = 'normal';
+///        String size = '20px';
+///
+///        void changeStyle(dynamic event) {
+///          style = event.target.checked ? 'italic' : 'normal';
+///        }
+///
+///        void changeWeight(dynamic event) {
+///          weight = event.target.checked ? 'bold' : 'normal';
+///        }
+///     }
+///
+/// In this example the `font-style`, `font-size` and `font-weight` styles will
+/// be updated based on the `style` property's value changes.
 @Directive(selector: "[ngStyle]", inputs: const ["rawStyle: ngStyle"])
 class NgStyle implements DoCheck {
   KeyValueDiffers _differs;
   ElementRef _ngEl;
   Renderer _renderer;
-  /** @internal */
   Map<String, String> _rawStyle;
-  /** @internal */
   KeyValueDiffer _differ;
   NgStyle(this._differs, this._ngEl, this._renderer) {}
   set rawStyle(Map<String, String> v) {

--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -18,62 +18,61 @@ class SwitchView {
   }
 }
 
-/**
- * Adds or removes DOM sub-trees when their match expressions match the switch expression.
- *
- * Elements within `NgSwitch` but without `NgSwitchWhen` or `NgSwitchDefault` directives will be
- * preserved at the location as specified in the template.
- *
- * `NgSwitch` simply inserts nested elements based on which match expression matches the value
- * obtained from the evaluated switch expression. In other words, you define a container element
- * (where you place the directive with a switch expression on the
- * `[ngSwitch]="..."` attribute), define any inner elements inside of the directive and
- * place a `[ngSwitchWhen]` attribute per element.
- *
- * The `ngSwitchWhen` property is used to inform `NgSwitch` which element to display when the
- * expression is evaluated. If a matching expression is not found via a `ngSwitchWhen` property
- * then an element with the `ngSwitchDefault` attribute is displayed.
- *
- * ### Example ([live demo](http://plnkr.co/edit/DQMTII95CbuqWrl3lYAs?p=preview))
- *
- * ```typescript
- * @Component({
- *   selector: 'app',
- *   template: `
- *     <p>Value = {{value}}</p>
- *     <button (click)="inc()">Increment</button>
- *
- *     <div [ngSwitch]="value">
- *       <p *ngSwitchWhen="'init'">increment to start</p>
- *       <p *ngSwitchWhen="0">0, increment again</p>
- *       <p *ngSwitchWhen="1">1, increment again</p>
- *       <p *ngSwitchWhen="2">2, stop incrementing</p>
- *       <p *ngSwitchDefault>&gt; 2, STOP!</p>
- *     </div>
- *
- *     <!-- alternate syntax -->
- *
- *     <p [ngSwitch]="value">
- *       <template ngSwitchWhen="init">increment to start</template>
- *       <template [ngSwitchWhen]="0">0, increment again</template>
- *       <template [ngSwitchWhen]="1">1, increment again</template>
- *       <template [ngSwitchWhen]="2">2, stop incrementing</template>
- *       <template ngSwitchDefault>&gt; 2, STOP!</template>
- *     </p>
- *   `,
- *   directives: [NgSwitch, NgSwitchWhen, NgSwitchDefault]
- * })
- * export class App {
- *   value = 'init';
- *
- *   inc() {
- *     this.value = this.value === 'init' ? 0 : this.value + 1;
- *   }
- * }
- *
- * bootstrap(App).catch(err => console.error(err));
- * ```
- */
+/// Adds or removes DOM sub-trees when their match expressions match the switch
+/// expression.
+///
+/// Elements within `NgSwitch` but without `NgSwitchWhen` or `NgSwitchDefault`
+/// directives will be preserved at the location as specified in the template.
+///
+/// `NgSwitch` simply inserts nested elements based on which match expression
+/// matches the value obtained from the evaluated switch expression. In other
+/// words, you define a container element (where you place the directive with a
+/// switch expression on the `[ngSwitch]="..."` attribute), define any inner
+/// elements inside of the directive and place a `[ngSwitchWhen]` attribute per
+/// element.
+///
+/// The `ngSwitchWhen` property is used to inform `NgSwitch` which element to
+/// display when the expression is evaluated. If a matching expression is not
+/// found via a `ngSwitchWhen` property then an element with the
+/// `ngSwitchDefault` attribute is displayed.
+///
+/// ### Example:
+///
+///     @Component(
+///       selector: 'app',
+///       template: '''
+///         <p>Value = {{value}}</p>
+///         <button (click)="inc()">Increment</button>
+///
+///         <div [ngSwitch]="value">
+///           <p *ngSwitchWhen="'init'">increment to start</p>
+///           <p *ngSwitchWhen="0">0, increment again</p>
+///           <p *ngSwitchWhen="1">1, increment again</p>
+///           <p *ngSwitchWhen="2">2, stop incrementing</p>
+///           <p *ngSwitchDefault>&gt; 2, STOP!</p>
+///         </div>
+///
+///         <!-- alternate syntax -->
+///
+///         <p [ngSwitch]="value">
+///           <template ngSwitchWhen="init">increment to start</template>
+///           <template [ngSwitchWhen]="0">0, increment again</template>
+///           <template [ngSwitchWhen]="1">1, increment again</template>
+///           <template [ngSwitchWhen]="2">2, stop incrementing</template>
+///           <template ngSwitchDefault>&gt; 2, STOP!</template>
+///         </p>
+///       ''',
+///       directives: const [NgSwitch, NgSwitchWhen, NgSwitchDefault]
+///     )
+///     class App {
+///       dynamic value = 'init';
+///
+///       void inc() {
+///         value = value === 'init' ? 0 : value + 1;
+///       }
+///     }
+///
+///     bootstrap(App).catch((err) => print(err));
 @Directive(selector: "[ngSwitch]", inputs: const ["ngSwitch"])
 class NgSwitch {
   dynamic _switchValue;
@@ -94,7 +93,6 @@ class NgSwitch {
     this._switchValue = value;
   }
 
-  /** @internal */
   void _onWhenValueChanged(dynamic oldWhen, dynamic newWhen, SwitchView view) {
     this._deregisterView(oldWhen, view);
     this._registerView(newWhen, view);
@@ -116,7 +114,6 @@ class NgSwitch {
     }
   }
 
-  /** @internal */
   void _emptyAllActiveViews() {
     var activeContainers = this._activeViews;
     for (var i = 0; i < activeContainers.length; i++) {
@@ -125,7 +122,6 @@ class NgSwitch {
     this._activeViews = [];
   }
 
-  /** @internal */
   void _activateViews(List<SwitchView> views) {
     // TODO(vicb): assert(this._activeViews.length === 0);
     if (isPresent(views)) {
@@ -136,7 +132,6 @@ class NgSwitch {
     }
   }
 
-  /** @internal */
   void _registerView(dynamic value, SwitchView view) {
     var views = this._valueViews[value];
     if (isBlank(views)) {
@@ -146,7 +141,6 @@ class NgSwitch {
     views.add(view);
   }
 
-  /** @internal */
   void _deregisterView(dynamic value, SwitchView view) {
     // `_WHEN_DEFAULT` is used a marker for non-registered whens
     if (identical(value, _WHEN_DEFAULT)) return;
@@ -160,21 +154,18 @@ class NgSwitch {
   }
 }
 
-/**
- * Insert the sub-tree when the `ngSwitchWhen` expression evaluates to the same value as the
- * enclosing switch expression.
- *
- * If multiple match expression match the switch expression value, all of them are displayed.
- *
- * See [NgSwitch] for more details and example.
- */
+/// Insert the sub-tree when the `ngSwitchWhen` expression evaluates to the same
+/// value as the enclosing switch expression.
+///
+/// If multiple match expression match the switch expression value, all of them
+/// are displayed.
+///
+/// See [NgSwitch] for more details and example.
 @Directive(selector: "[ngSwitchWhen]", inputs: const ["ngSwitchWhen"])
 class NgSwitchWhen {
   // `_WHEN_DEFAULT` is used as a marker for a not yet initialized value
 
-  /** @internal */
   dynamic _value = _WHEN_DEFAULT;
-  /** @internal */
   SwitchView _view;
   NgSwitch _switch;
   NgSwitchWhen(ViewContainerRef viewContainer, TemplateRef templateRef,
@@ -188,12 +179,10 @@ class NgSwitchWhen {
   }
 }
 
-/**
- * Default case statements are displayed when no match expression matches the switch expression
- * value.
- *
- * See [NgSwitch] for more details and example.
- */
+/// Default case statements are displayed when no match expression matches the
+/// switch expression value.
+///
+/// See [NgSwitch] for more details and example.
 @Directive(selector: "[ngSwitchDefault]")
 class NgSwitchDefault {
   NgSwitchDefault(ViewContainerRef viewContainer, TemplateRef templateRef,

--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -38,41 +38,43 @@ class SwitchView {
 ///
 /// ### Example:
 ///
-///     @Component(
-///       selector: 'app',
-///       template: '''
-///         <p>Value = {{value}}</p>
-///         <button (click)="inc()">Increment</button>
+/// ```dart
+/// @Component(
+///   selector: 'app',
+///   template: '''
+///     <p>Value = {{value}}</p>
+///     <button (click)="inc()">Increment</button>
 ///
-///         <div [ngSwitch]="value">
-///           <p *ngSwitchWhen="'init'">increment to start</p>
-///           <p *ngSwitchWhen="0">0, increment again</p>
-///           <p *ngSwitchWhen="1">1, increment again</p>
-///           <p *ngSwitchWhen="2">2, stop incrementing</p>
-///           <p *ngSwitchDefault>&gt; 2, STOP!</p>
-///         </div>
+///     <div [ngSwitch]="value">
+///       <p *ngSwitchWhen="'init'">increment to start</p>
+///       <p *ngSwitchWhen="0">0, increment again</p>
+///       <p *ngSwitchWhen="1">1, increment again</p>
+///       <p *ngSwitchWhen="2">2, stop incrementing</p>
+///       <p *ngSwitchDefault>&gt; 2, STOP!</p>
+///     </div>
 ///
-///         <!-- alternate syntax -->
+///     <!-- alternate syntax -->
 ///
-///         <p [ngSwitch]="value">
-///           <template ngSwitchWhen="init">increment to start</template>
-///           <template [ngSwitchWhen]="0">0, increment again</template>
-///           <template [ngSwitchWhen]="1">1, increment again</template>
-///           <template [ngSwitchWhen]="2">2, stop incrementing</template>
-///           <template ngSwitchDefault>&gt; 2, STOP!</template>
-///         </p>
-///       ''',
-///       directives: const [NgSwitch, NgSwitchWhen, NgSwitchDefault]
-///     )
-///     class App {
-///       dynamic value = 'init';
+///     <p [ngSwitch]="value">
+///       <template ngSwitchWhen="init">increment to start</template>
+///       <template [ngSwitchWhen]="0">0, increment again</template>
+///       <template [ngSwitchWhen]="1">1, increment again</template>
+///       <template [ngSwitchWhen]="2">2, stop incrementing</template>
+///       <template ngSwitchDefault>&gt; 2, STOP!</template>
+///     </p>
+///   ''',
+///   directives: const [NgSwitch, NgSwitchWhen, NgSwitchDefault]
+/// )
+/// class App {
+///   dynamic value = 'init';
 ///
-///       void inc() {
-///         value = value === 'init' ? 0 : value + 1;
-///       }
-///     }
+///   void inc() {
+///     value = value === 'init' ? 0 : value + 1;
+///   }
+/// }
 ///
-///     bootstrap(App).catch((err) => print(err));
+/// bootstrap(App).catch((err) => print(err));
+/// ```
 @Directive(selector: "[ngSwitch]", inputs: const ["ngSwitch"])
 class NgSwitch {
   dynamic _switchValue;

--- a/lib/src/common/directives/ng_template_outlet.dart
+++ b/lib/src/common/directives/ng_template_outlet.dart
@@ -2,12 +2,10 @@ import "package:angular2/core.dart"
     show Directive, Input, ViewContainerRef, ViewRef, TemplateRef;
 import "package:angular2/src/facade/lang.dart" show isPresent;
 
-/**
- * Creates and inserts an embedded view based on a prepared `TemplateRef`.
- *
- * ### Syntax
- * - `<template [ngTemplateOutlet]="templateRefExpression"></template>`
- */
+/// Creates and inserts an embedded view based on a prepared `TemplateRef`.
+///
+/// ### Syntax
+/// - `<template [ngTemplateOutlet]="templateRefExpression"></template>`
 @Directive(selector: "[ngTemplateOutlet]")
 class NgTemplateOutlet {
   ViewContainerRef _viewContainerRef;

--- a/lib/src/common/forms.dart
+++ b/lib/src/common/forms.dart
@@ -1,16 +1,10 @@
-/**
- * 
- * 
- * This module is used for handling user input, by defining and building a [ControlGroup] that
- * consists of
- * [Control] objects, and mapping them onto the DOM. [Control] objects can then be used
- * to read information
- * from the form DOM elements.
- *
- * This module is not included in the `angular2` module; you must import the forms module
- * explicitly.
- *
- */
+// This module is used for handling user input, by defining and building a
+// [ControlGroup] that consists of [Control] objects, and mapping them onto
+// the DOM. [Control] objects can then be used to read information from the
+// form DOM elements.
+//
+// This module is not included in the `angular2` module; you must import the
+// forms module explicitly.
 
 import "forms/directives/radio_control_value_accessor.dart"
     show RadioControlRegistry;
@@ -49,19 +43,11 @@ export "forms/model.dart"
 export "forms/validators.dart"
     show NG_VALIDATORS, NG_ASYNC_VALIDATORS, Validators;
 
-/**
- * Shorthand set of providers used for building Angular forms.
- *
- * ### Example
- *
- * ```typescript
- * bootstrap(MyApp, [FORM_PROVIDERS]);
- * ```
- */
+/// Shorthand set of providers used for building Angular forms.
+///
+/// ### Example
+///     bootstrap(MyApp, [FORM_PROVIDERS]);
 const List<Type> FORM_PROVIDERS = const [FormBuilder, RadioControlRegistry];
-/**
- * See [FORM_PROVIDERS] instead.
- *
- * 
- */
+
+/// See [FORM_PROVIDERS] instead.
 const FORM_BINDINGS = FORM_PROVIDERS;

--- a/lib/src/common/forms.dart
+++ b/lib/src/common/forms.dart
@@ -46,7 +46,10 @@ export "forms/validators.dart"
 /// Shorthand set of providers used for building Angular forms.
 ///
 /// ### Example
-///     bootstrap(MyApp, [FORM_PROVIDERS]);
+///
+/// ```dart
+/// bootstrap(MyApp, [FORM_PROVIDERS]);
+/// ````
 const List<Type> FORM_PROVIDERS = const [FormBuilder, RadioControlRegistry];
 
 /// See [FORM_PROVIDERS] instead.

--- a/lib/src/common/forms/directives.dart
+++ b/lib/src/common/forms/directives.dart
@@ -51,11 +51,13 @@ export "directives/validators.dart"
 ///
 /// ### Example
 ///
-///     @Component(
-///       selector: 'my-app',
-///       directives: const [FORM_DIRECTIVES]
-///     )
-///     class MyApp {}
+/// ```dart
+/// @Component(
+///   selector: 'my-app',
+///   directives: const [FORM_DIRECTIVES]
+/// )
+/// class MyApp {}
+/// ```
 const List<Type> FORM_DIRECTIVES = const [
   NgControlName,
   NgControlGroup,

--- a/lib/src/common/forms/directives.dart
+++ b/lib/src/common/forms/directives.dart
@@ -44,22 +44,18 @@ export "directives/validators.dart"
         MaxLengthValidator,
         PatternValidator;
 
-/**
- *
- * A list of all the form directives used as part of a `@Component` annotation.
- *
- *  This is a shorthand for importing them each individually.
- *
- * ### Example
- *
- * ```typescript
- * @Component({
- *   selector: 'my-app',
- *   directives: [FORM_DIRECTIVES]
- * })
- * class MyApp {}
- * ```
- */
+///
+/// A list of all the form directives used as part of a `@Component` annotation.
+///
+///  This is a shorthand for importing them each individually.
+///
+/// ### Example
+///
+///     @Component(
+///       selector: 'my-app',
+///       directives: const [FORM_DIRECTIVES]
+///     )
+///     class MyApp {}
 const List<Type> FORM_DIRECTIVES = const [
   NgControlName,
   NgControlGroup,

--- a/lib/src/common/forms/directives/abstract_control_directive.dart
+++ b/lib/src/common/forms/directives/abstract_control_directive.dart
@@ -2,11 +2,9 @@ import "package:angular2/src/facade/lang.dart" show isPresent;
 
 import "../model.dart" show AbstractControl;
 
-/**
- * Base class for control directives.
- *
- * Only used internally in the forms module.
- */
+/// Base class for control directives.
+///
+/// Only used internally in the forms module.
 abstract class AbstractControlDirective {
   AbstractControl get control;
 

--- a/lib/src/common/forms/directives/checkbox_value_accessor.dart
+++ b/lib/src/common/forms/directives/checkbox_value_accessor.dart
@@ -7,14 +7,10 @@ import "control_value_accessor.dart"
 const CHECKBOX_VALUE_ACCESSOR = const Provider(NG_VALUE_ACCESSOR,
     useExisting: CheckboxControlValueAccessor, multi: true);
 
-/**
- * The accessor for writing a value and listening to changes on a checkbox input element.
- *
- *  ### Example
- *  ```
- *  <input type="checkbox" ngControl="rememberLogin">
- *  ```
- */
+/// The accessor for writing a value and listening to changes on a checkbox input element.
+///
+/// ### Example
+///     <input type="checkbox" ngControl="rememberLogin">
 @Directive(
     selector:
         "input[type=checkbox][ngControl],input[type=checkbox][ngFormControl],input[type=checkbox][ngModel]",

--- a/lib/src/common/forms/directives/control_container.dart
+++ b/lib/src/common/forms/directives/control_container.dart
@@ -1,23 +1,17 @@
 import "abstract_control_directive.dart" show AbstractControlDirective;
 import "form_interface.dart" show Form;
 
-/**
- * A directive that contains multiple [NgControl]s.
- *
- * Only used by the forms module.
- */
+/// A directive that contains multiple [NgControl]s.
+///
+/// Only used by the forms module.
 class ControlContainer extends AbstractControlDirective {
   String name;
-  /**
-   * Get the form to which this container belongs.
-   */
+  /// Get the form to which this container belongs.
   Form get formDirective {
     return null;
   }
 
-  /**
-   * Get the path to this container.
-   */
+  /// Get the path to this container.
   @override
   List<String> get path {
     return null;

--- a/lib/src/common/forms/directives/control_value_accessor.dart
+++ b/lib/src/common/forms/directives/control_value_accessor.dart
@@ -1,31 +1,22 @@
 import "package:angular2/core.dart" show OpaqueToken;
 
-/**
- * A bridge between a control and a native element.
- *
- * A `ControlValueAccessor` abstracts the operations of writing a new value to a
- * DOM element representing an input control.
- *
- * Please see [DefaultValueAccessor] for more information.
- */
+/// A bridge between a control and a native element.
+///
+/// A `ControlValueAccessor` abstracts the operations of writing a new value to a
+/// DOM element representing an input control.
+///
+/// Please see [DefaultValueAccessor] for more information.
 abstract class ControlValueAccessor<T> {
-  /**
-   * Write a new value to the element.
-   */
+  /// Write a new value to the element.
   void writeValue(T obj);
-  /**
-   * Set the function to be called when the control receives a change event.
-   */
+  /// Set the function to be called when the control receives a change event.
   void registerOnChange(dynamic fn(T value));
-  /**
-   * Set the function to be called when the control receives a touch event.
-   */
+  /// Set the function to be called when the control receives a touch event.
   void registerOnTouched(dynamic fn());
 }
 
-/**
- * Used to provide a [ControlValueAccessor] for form controls.
- *
- * See [DefaultValueAccessor] for how to implement one.
- */
+/// Used to provide a [ControlValueAccessor] for form controls.
+///
+/// See [DefaultValueAccessor] for how to implement one.
+////
 const OpaqueToken NG_VALUE_ACCESSOR = const OpaqueToken("NgValueAccessor");

--- a/lib/src/common/forms/directives/default_value_accessor.dart
+++ b/lib/src/common/forms/directives/default_value_accessor.dart
@@ -8,15 +8,11 @@ import "control_value_accessor.dart"
 const DEFAULT_VALUE_ACCESSOR = const Provider(NG_VALUE_ACCESSOR,
     useExisting: DefaultValueAccessor, multi: true);
 
-/**
- * The default accessor for writing a value and listening to changes that is used by the
- * [NgModel], [NgFormControl], and [NgControlName] directives.
- *
- *  ### Example
- *  ```
- *  <input type="text" ngControl="searchQuery">
- *  ```
- */
+/// The default accessor for writing a value and listening to changes that is used by the
+/// [NgModel], [NgFormControl], and [NgControlName] directives.
+///
+/// ### Example
+///     <input type="text" ngControl="searchQuery">
 @Directive(
     selector:
         "input:not([type=checkbox])[ngControl],textarea[ngControl],input:not([type=checkbox])[ngFormControl],textarea[ngFormControl],input:not([type=checkbox])[ngModel],textarea[ngModel],[ngDefaultControl]",

--- a/lib/src/common/forms/directives/form_interface.dart
+++ b/lib/src/common/forms/directives/form_interface.dart
@@ -2,38 +2,22 @@ import "../model.dart" show Control, ControlGroup;
 import "ng_control.dart" show NgControl;
 import "ng_control_group.dart" show NgControlGroup;
 
-/**
- * An interface that [NgFormModel] and [NgForm] implement.
- *
- * Only used by the forms module.
- */
+/// An interface that [NgFormModel] and [NgForm] implement.
+///
+/// Only used by the forms module.
 abstract class Form {
-  /**
-   * Add a control to this form.
-   */
+  /// Add a control to this form.
   void addControl(NgControl dir);
-  /**
-   * Remove a control from this form.
-   */
+  /// Remove a control from this form.
   void removeControl(NgControl dir);
-  /**
-   * Look up the [Control] associated with a particular [NgControl].
-   */
+  /// Look up the [Control] associated with a particular [NgControl].
   Control getControl(NgControl dir);
-  /**
-   * Add a group of controls to this form.
-   */
+  /// Add a group of controls to this form.
   void addControlGroup(NgControlGroup dir);
-  /**
-   * Remove a group of controls from this form.
-   */
+  /// Remove a group of controls from this form.
   void removeControlGroup(NgControlGroup dir);
-  /**
-   * Look up the [ControlGroup] associated with a particular [NgControlGroup].
-   */
+  /// Look up the [ControlGroup] associated with a particular [NgControlGroup].
   ControlGroup getControlGroup(NgControlGroup dir);
-  /**
-   * Update the model for a particular control with a new value.
-   */
+  /// Update the model for a particular control with a new value.
   void updateModel(NgControl dir, dynamic value);
 }

--- a/lib/src/common/forms/directives/ng_control.dart
+++ b/lib/src/common/forms/directives/ng_control.dart
@@ -2,12 +2,10 @@ import "abstract_control_directive.dart" show AbstractControlDirective;
 import "control_value_accessor.dart" show ControlValueAccessor;
 import "validators.dart" show AsyncValidatorFn, ValidatorFn;
 
-/**
- * A base class that all control directive extend.
- * It binds a [Control] object to a DOM element.
- *
- * Used internally by Angular forms.
- */
+/// A base class that all control directive extend.
+/// It binds a [Control] object to a DOM element.
+///
+/// Used internally by Angular forms.
 abstract class NgControl extends AbstractControlDirective {
   String name = null;
   ControlValueAccessor valueAccessor = null;

--- a/lib/src/common/forms/directives/ng_control_group.dart
+++ b/lib/src/common/forms/directives/ng_control_group.dart
@@ -27,38 +27,40 @@ const controlGroupProvider =
 ///
 /// ### Example:
 ///
-///     @Component(
-///       selector: 'my-app',
-///       directives: const [FORM_DIRECTIVES],
-///       template: '''
-///         <div>
-///           <h2>Angular2 Control &amp; ControlGroup Example</h2>
-///           <form #f="ngForm">
-///             <div ngControlGroup="name" #cg-name="form">
-///               <h3>Enter your name:</h3>
-///               <p>First: <input ngControl="first" required></p>
-///               <p>Middle: <input ngControl="middle"></p>
-///               <p>Last: <input ngControl="last" required></p>
-///             </div>
-///             <h3>Name value:</h3>
-///             <pre>{{valueOf(cgName)}}</pre>
-///             <p>Name is {{cgName?.control?.valid ? "valid" : "invalid"}}</p>
-///             <h3>What's your favorite food?</h3>
-///             <p><input ngControl="food"></p>
-///             <h3>Form value</h3>
-///             <pre>{{valueOf(f)}}</pre>
-///           </form>
+/// ```dart
+/// @Component(
+///   selector: 'my-app',
+///   directives: const [FORM_DIRECTIVES],
+///   template: '''
+///     <div>
+///       <h2>Angular2 Control &amp; ControlGroup Example</h2>
+///       <form #f="ngForm">
+///         <div ngControlGroup="name" #cg-name="form">
+///           <h3>Enter your name:</h3>
+///           <p>First: <input ngControl="first" required></p>
+///           <p>Middle: <input ngControl="middle"></p>
+///           <p>Last: <input ngControl="last" required></p>
 ///         </div>
-///       '''
-///     })
-///     class App {
-///       String valueOf(NgControlGroup cg) {
-///         if (cg.control == null) {
-///           return null;
-///         }
-///         return JSON.encode(cg.control.value, null, 2);
-///       }
+///         <h3>Name value:</h3>
+///         <pre>{{valueOf(cgName)}}</pre>
+///         <p>Name is {{cgName?.control?.valid ? "valid" : "invalid"}}</p>
+///         <h3>What's your favorite food?</h3>
+///         <p><input ngControl="food"></p>
+///         <h3>Form value</h3>
+///         <pre>{{valueOf(f)}}</pre>
+///       </form>
+///     </div>
+///   '''
+/// })
+/// class App {
+///   String valueOf(NgControlGroup cg) {
+///     if (cg.control == null) {
+///       return null;
 ///     }
+///     return JSON.encode(cg.control.value, null, 2);
+///   }
+/// }
+/// ```
 ///
 /// This example declares a control group for a user's name. The value and
 /// validation state of this group can be accessed separately from the overall

--- a/lib/src/common/forms/directives/ng_control_group.dart
+++ b/lib/src/common/forms/directives/ng_control_group.dart
@@ -21,51 +21,48 @@ import "validators.dart" show AsyncValidatorFn, ValidatorFn;
 const controlGroupProvider =
     const Provider(ControlContainer, useExisting: NgControlGroup);
 
-/**
- * Creates and binds a control group to a DOM element.
- *
- * This directive can only be used as a child of [NgForm] or [NgFormModel].
- *
- * ### Example ([live demo](http://plnkr.co/edit/7EJ11uGeaggViYM6T5nq?p=preview))
- *
- * ```typescript
- * @Component({
- *   selector: 'my-app',
- *   directives: [FORM_DIRECTIVES],
- *   template: `
- *     <div>
- *       <h2>Angular2 Control &amp; ControlGroup Example</h2>
- *       <form #f="ngForm">
- *         <div ngControlGroup="name" #cg-name="form">
- *           <h3>Enter your name:</h3>
- *           <p>First: <input ngControl="first" required></p>
- *           <p>Middle: <input ngControl="middle"></p>
- *           <p>Last: <input ngControl="last" required></p>
- *         </div>
- *         <h3>Name value:</h3>
- *         <pre>{{valueOf(cgName)}}</pre>
- *         <p>Name is {{cgName?.control?.valid ? "valid" : "invalid"}}</p>
- *         <h3>What's your favorite food?</h3>
- *         <p><input ngControl="food"></p>
- *         <h3>Form value</h3>
- *         <pre>{{valueOf(f)}}</pre>
- *       </form>
- *     </div>
- *   `
- * })
- * export class App {
- *   valueOf(cg: NgControlGroup): string {
- *     if (cg.control == null) {
- *       return null;
- *     }
- *     return JSON.stringify(cg.control.value, null, 2);
- *   }
- * }
- * ```
- *
- * This example declares a control group for a user's name. The value and validation state of
- * this group can be accessed separately from the overall form.
- */
+/// Creates and binds a control group to a DOM element.
+///
+/// This directive can only be used as a child of [NgForm] or [NgFormModel].
+///
+/// ### Example:
+///
+///     @Component(
+///       selector: 'my-app',
+///       directives: const [FORM_DIRECTIVES],
+///       template: '''
+///         <div>
+///           <h2>Angular2 Control &amp; ControlGroup Example</h2>
+///           <form #f="ngForm">
+///             <div ngControlGroup="name" #cg-name="form">
+///               <h3>Enter your name:</h3>
+///               <p>First: <input ngControl="first" required></p>
+///               <p>Middle: <input ngControl="middle"></p>
+///               <p>Last: <input ngControl="last" required></p>
+///             </div>
+///             <h3>Name value:</h3>
+///             <pre>{{valueOf(cgName)}}</pre>
+///             <p>Name is {{cgName?.control?.valid ? "valid" : "invalid"}}</p>
+///             <h3>What's your favorite food?</h3>
+///             <p><input ngControl="food"></p>
+///             <h3>Form value</h3>
+///             <pre>{{valueOf(f)}}</pre>
+///           </form>
+///         </div>
+///       '''
+///     })
+///     class App {
+///       String valueOf(NgControlGroup cg) {
+///         if (cg.control == null) {
+///           return null;
+///         }
+///         return JSON.encode(cg.control.value, null, 2);
+///       }
+///     }
+///
+/// This example declares a control group for a user's name. The value and
+/// validation state of this group can be accessed separately from the overall
+/// form.
 @Directive(
     selector: "[ngControlGroup]",
     providers: const [controlGroupProvider],
@@ -74,7 +71,6 @@ const controlGroupProvider =
 class NgControlGroup extends ControlContainer implements OnInit, OnDestroy {
   List<dynamic> _validators;
   List<dynamic> _asyncValidators;
-  /** @internal */
   ControlContainer _parent;
   NgControlGroup(
       @Host() @SkipSelf() ControlContainer parent,
@@ -92,23 +88,17 @@ class NgControlGroup extends ControlContainer implements OnInit, OnDestroy {
     this.formDirective.removeControlGroup(this);
   }
 
-  /**
-   * Get the [ControlGroup] backing this binding.
-   */
+  /// Get the [ControlGroup] backing this binding.
   ControlGroup get control {
     return this.formDirective.getControlGroup(this);
   }
 
-  /**
-   * Get the path to this control group.
-   */
+  /// Get the path to this control group.
   List<String> get path {
     return controlPath(this.name, this._parent);
   }
 
-  /**
-   * Get the [Form] to which this group belongs.
-   */
+  /// Get the [Form] to which this group belongs.
   Form get formDirective {
     return this._parent.formDirective;
   }

--- a/lib/src/common/forms/directives/ng_control_name.dart
+++ b/lib/src/common/forms/directives/ng_control_name.dart
@@ -31,61 +31,55 @@ import "validators.dart" show ValidatorFn, AsyncValidatorFn;
 const controlNameBinding =
     const Provider(NgControl, useExisting: NgControlName);
 
-/**
- * Creates and binds a control with a specified name to a DOM element.
- *
- * This directive can only be used as a child of [NgForm] or [NgFormModel].
+/// Creates and binds a control with a specified name to a DOM element.
+///
+/// This directive can only be used as a child of [NgForm] or [NgFormModel].
 
- * ### Example
- *
- * In this example, we create the login and password controls.
- * We can work with each control separately: check its validity, get its value, listen to its
- * changes.
- *
- *  ```
- * @Component({
- *      selector: "login-comp",
- *      directives: [FORM_DIRECTIVES],
- *      template: `
- *        <form #f="ngForm" (submit)='onLogIn(f.value)'>
- *          Login <input type='text' ngControl='login' #l="form">
- *          <div *ngIf="!l.valid">Login is invalid</div>
- *
- *          Password <input type='password' ngControl='password'>
- *          <button type='submit'>Log in!</button>
- *        </form>
- *      `})
- * class LoginComp {
- *  onLogIn(value): void {
- *    // value === {login: 'some login', password: 'some password'}
- *  }
- * }
- *  ```
- *
- * We can also use ngModel to bind a domain model to the form.
- *
- *  ```
- * @Component({
- *      selector: "login-comp",
- *      directives: [FORM_DIRECTIVES],
- *      template: `
- *        <form (submit)='onLogIn()'>
- *          Login <input type='text' ngControl='login' [(ngModel)]="credentials.login">
- *          Password <input type='password' ngControl='password'
- *                          [(ngModel)]="credentials.password">
- *          <button type='submit'>Log in!</button>
- *        </form>
- *      `})
- * class LoginComp {
- *  credentials: {login:string, password:string};
- *
- *  onLogIn(): void {
- *    // this.credentials.login === "some login"
- *    // this.credentials.password === "some password"
- *  }
- * }
- *  ```
- */
+/// ### Example
+///
+/// In this example, we create the login and password controls.
+/// We can work with each control separately: check its validity, get its value, listen to its
+/// changes.
+///
+///     @Component(
+///          selector: "login-comp",
+///          directives: const [FORM_DIRECTIVES],
+///          template: '''
+///            <form #f="ngForm" (submit)='onLogIn(f.value)'>
+///              Login <input type='text' ngControl='login' #l="form">
+///              <div *ngIf="!l.valid">Login is invalid</div>
+///
+///              Password <input type='password' ngControl='password'>
+///              <button type='submit'>Log in!</button>
+///            </form>
+///          ''')
+///     class LoginComp {
+///      void onLogIn(value) {
+///        // value === {'login': 'some login', 'password': 'some password'}
+///      }
+///     }
+///
+/// We can also use ngModel to bind a domain model to the form.
+///
+///     @Component(
+///          selector: "login-comp",
+///          directives: [FORM_DIRECTIVES],
+///          template: '''
+///            <form (submit)='onLogIn()'>
+///              Login <input type='text' ngControl='login' [(ngModel)]="credentials.login">
+///              Password <input type='password' ngControl='password'
+///                              [(ngModel)]="credentials.password">
+///              <button type='submit'>Log in!</button>
+///            </form>
+///          ''')
+///     class LoginComp {
+///      credentials: {login:string, password:string};
+///
+///      onLogIn(): void {
+///        // this.credentials.login === "some login"
+///        // this.credentials.password === "some password"
+///      }
+///     }
 @Directive(
     selector: "[ngControl]",
     providers: const [controlNameBinding],

--- a/lib/src/common/forms/directives/ng_control_name.dart
+++ b/lib/src/common/forms/directives/ng_control_name.dart
@@ -41,45 +41,49 @@ const controlNameBinding =
 /// We can work with each control separately: check its validity, get its value, listen to its
 /// changes.
 ///
-///     @Component(
-///          selector: "login-comp",
-///          directives: const [FORM_DIRECTIVES],
-///          template: '''
-///            <form #f="ngForm" (submit)='onLogIn(f.value)'>
-///              Login <input type='text' ngControl='login' #l="form">
-///              <div *ngIf="!l.valid">Login is invalid</div>
+/// ```dart
+/// @Component(
+///      selector: "login-comp",
+///      directives: const [FORM_DIRECTIVES],
+///      template: '''
+///        <form #f="ngForm" (submit)='onLogIn(f.value)'>
+///          Login <input type='text' ngControl='login' #l="form">
+///          <div *ngIf="!l.valid">Login is invalid</div>
 ///
-///              Password <input type='password' ngControl='password'>
-///              <button type='submit'>Log in!</button>
-///            </form>
-///          ''')
-///     class LoginComp {
-///      void onLogIn(value) {
-///        // value === {'login': 'some login', 'password': 'some password'}
-///      }
-///     }
+///          Password <input type='password' ngControl='password'>
+///          <button type='submit'>Log in!</button>
+///        </form>
+///      ''')
+/// class LoginComp {
+///  void onLogIn(value) {
+///    // value === {'login': 'some login', 'password': 'some password'}
+///  }
+/// }
+/// ```
 ///
 /// We can also use ngModel to bind a domain model to the form.
 ///
-///     @Component(
-///          selector: "login-comp",
-///          directives: [FORM_DIRECTIVES],
-///          template: '''
-///            <form (submit)='onLogIn()'>
-///              Login <input type='text' ngControl='login' [(ngModel)]="credentials.login">
-///              Password <input type='password' ngControl='password'
-///                              [(ngModel)]="credentials.password">
-///              <button type='submit'>Log in!</button>
-///            </form>
-///          ''')
-///     class LoginComp {
-///      credentials: {login:string, password:string};
+/// ```dart
+/// @Component(
+///      selector: "login-comp",
+///      directives: [FORM_DIRECTIVES],
+///      template: '''
+///        <form (submit)='onLogIn()'>
+///          Login <input type='text' ngControl='login' [(ngModel)]="credentials.login">
+///          Password <input type='password' ngControl='password'
+///                          [(ngModel)]="credentials.password">
+///          <button type='submit'>Log in!</button>
+///        </form>
+///      ''')
+/// class LoginComp {
+///  credentials: {login:string, password:string};
 ///
-///      onLogIn(): void {
-///        // this.credentials.login === "some login"
-///        // this.credentials.password === "some password"
-///      }
-///     }
+///  onLogIn(): void {
+///    // this.credentials.login === "some login"
+///    // this.credentials.password === "some password"
+///  }
+/// }
+/// ```
 @Directive(
     selector: "[ngControl]",
     providers: const [controlNameBinding],

--- a/lib/src/common/forms/directives/ng_control_status.dart
+++ b/lib/src/common/forms/directives/ng_control_status.dart
@@ -3,10 +3,8 @@ import "package:angular2/src/facade/lang.dart" show isPresent;
 
 import "ng_control.dart" show NgControl;
 
-/**
- * Directive automatically applied to Angular forms that sets CSS classes
- * based on control status (valid/invalid/dirty/etc).
- */
+/// Directive automatically applied to Angular forms that sets CSS classes
+/// based on control status (valid/invalid/dirty/etc).
 @Directive(selector: "[ngControl],[ngModel],[ngFormControl]", host: const {
   "[class.ng-untouched]": "ngClassUntouched",
   "[class.ng-touched]": "ngClassTouched",

--- a/lib/src/common/forms/directives/ng_form.dart
+++ b/lib/src/common/forms/directives/ng_form.dart
@@ -43,38 +43,40 @@ const formDirectiveProvider =
 ///
 /// ### Example
 ///
-///     @Component(
-///       selector: 'my-app',
-///       template: '''
-///         <div>
-///           <p>Submit the form to see the data object Angular builds</p>
-///           <h2>NgForm demo</h2>
-///           <form #f="ngForm" (ngSubmit)="onSubmit(f.value)">
-///             <h3>Control group: credentials</h3>
-///             <div ngControlGroup="credentials">
-///               <p>Login: <input type="text" ngControl="login"></p>
-///               <p>Password: <input type="password" ngControl="password"></p>
-///             </div>
-///             <h3>Control group: person</h3>
-///             <div ngControlGroup="person">
-///               <p>First name: <input type="text" ngControl="firstName"></p>
-///               <p>Last name: <input type="text" ngControl="lastName"></p>
-///             </div>
-///             <button type="submit">Submit Form</button>
-///           <p>Form data submitted:</p>
-///           </form>
-///           <pre>{{data}}</pre>
-///         </div>''',
-///       directives: const [CORE_DIRECTIVES, FORM_DIRECTIVES]
-///     })
-///     class App {
+/// ```dart
+/// @Component(
+///   selector: 'my-app',
+///   template: '''
+///     <div>
+///       <p>Submit the form to see the data object Angular builds</p>
+///       <h2>NgForm demo</h2>
+///       <form #f="ngForm" (ngSubmit)="onSubmit(f.value)">
+///         <h3>Control group: credentials</h3>
+///         <div ngControlGroup="credentials">
+///           <p>Login: <input type="text" ngControl="login"></p>
+///           <p>Password: <input type="password" ngControl="password"></p>
+///         </div>
+///         <h3>Control group: person</h3>
+///         <div ngControlGroup="person">
+///           <p>First name: <input type="text" ngControl="firstName"></p>
+///           <p>Last name: <input type="text" ngControl="lastName"></p>
+///         </div>
+///         <button type="submit">Submit Form</button>
+///       <p>Form data submitted:</p>
+///       </form>
+///       <pre>{{data}}</pre>
+///     </div>''',
+///   directives: const [CORE_DIRECTIVES, FORM_DIRECTIVES]
+/// })
+/// class App {
 ///
-///       String data;
+///   String data;
 ///
-///       void onSubmit(data) {
-///         this.data = JSON.encode(data);
-///       }
-///     }
+///   void onSubmit(data) {
+///     this.data = JSON.encode(data);
+///   }
+/// }
+/// ```
 @Directive(
     selector: "form:not([ngNoForm]):not([ngFormModel]),ngForm,[ngForm]",
     providers: const [formDirectiveProvider],

--- a/lib/src/common/forms/directives/ng_form.dart
+++ b/lib/src/common/forms/directives/ng_form.dart
@@ -22,65 +22,59 @@ import "shared.dart"
 const formDirectiveProvider =
     const Provider(ControlContainer, useExisting: NgForm);
 
-/**
- * If `NgForm` is bound in a component, `<form>` elements in that component will be
- * upgraded to use the Angular form system.
- *
- * ### Typical Use
- *
- * Include `FORM_DIRECTIVES` in the `directives` section of a [View] annotation
- * to use `NgForm` and its associated controls.
- *
- * ### Structure
- *
- * An Angular form is a collection of `Control`s in some hierarchy.
- * `Control`s can be at the top level or can be organized in `ControlGroup`s
- * or `ControlArray`s. This hierarchy is reflected in the form's `value`, a
- * JSON object that mirrors the form structure.
- *
- * ### Submission
- *
- * The `ngSubmit` event signals when the user triggers a form submission.
- *
- * ### Example ([live demo](http://plnkr.co/edit/ltdgYj4P0iY64AR71EpL?p=preview))
- *
- *  ```typescript
- * @Component({
- *   selector: 'my-app',
- *   template: `
- *     <div>
- *       <p>Submit the form to see the data object Angular builds</p>
- *       <h2>NgForm demo</h2>
- *       <form #f="ngForm" (ngSubmit)="onSubmit(f.value)">
- *         <h3>Control group: credentials</h3>
- *         <div ngControlGroup="credentials">
- *           <p>Login: <input type="text" ngControl="login"></p>
- *           <p>Password: <input type="password" ngControl="password"></p>
- *         </div>
- *         <h3>Control group: person</h3>
- *         <div ngControlGroup="person">
- *           <p>First name: <input type="text" ngControl="firstName"></p>
- *           <p>Last name: <input type="text" ngControl="lastName"></p>
- *         </div>
- *         <button type="submit">Submit Form</button>
- *       <p>Form data submitted:</p>
- *       </form>
- *       <pre>{{data}}</pre>
- *     </div>
- * `,
- *   directives: [CORE_DIRECTIVES, FORM_DIRECTIVES]
- * })
- * export class App {
- *   constructor() {}
- *
- *   data: string;
- *
- *   onSubmit(data) {
- *     this.data = JSON.stringify(data, null, 2);
- *   }
- * }
- *  ```
- */
+/// If `NgForm` is bound in a component, `<form>` elements in that component
+/// will be upgraded to use the Angular form system.
+///
+/// ### Typical Use
+///
+/// Include `FORM_DIRECTIVES` in the `directives` section of a [View] annotation
+/// to use `NgForm` and its associated controls.
+///
+/// ### Structure
+///
+/// An Angular form is a collection of `Control`s in some hierarchy.
+/// `Control`s can be at the top level or can be organized in `ControlGroup`s
+/// or `ControlArray`s. This hierarchy is reflected in the form's `value`, a
+/// JSON object that mirrors the form structure.
+///
+/// ### Submission
+///
+/// The `ngSubmit` event signals when the user triggers a form submission.
+///
+/// ### Example
+///
+///     @Component(
+///       selector: 'my-app',
+///       template: '''
+///         <div>
+///           <p>Submit the form to see the data object Angular builds</p>
+///           <h2>NgForm demo</h2>
+///           <form #f="ngForm" (ngSubmit)="onSubmit(f.value)">
+///             <h3>Control group: credentials</h3>
+///             <div ngControlGroup="credentials">
+///               <p>Login: <input type="text" ngControl="login"></p>
+///               <p>Password: <input type="password" ngControl="password"></p>
+///             </div>
+///             <h3>Control group: person</h3>
+///             <div ngControlGroup="person">
+///               <p>First name: <input type="text" ngControl="firstName"></p>
+///               <p>Last name: <input type="text" ngControl="lastName"></p>
+///             </div>
+///             <button type="submit">Submit Form</button>
+///           <p>Form data submitted:</p>
+///           </form>
+///           <pre>{{data}}</pre>
+///         </div>''',
+///       directives: const [CORE_DIRECTIVES, FORM_DIRECTIVES]
+///     })
+///     class App {
+///
+///       String data;
+///
+///       void onSubmit(data) {
+///         this.data = JSON.encode(data);
+///       }
+///     }
 @Directive(
     selector: "form:not([ngNoForm]):not([ngFormModel]),ngForm,[ngForm]",
     providers: const [formDirectiveProvider],
@@ -180,7 +174,6 @@ class NgForm extends ControlContainer implements Form {
     return false;
   }
 
-  /** @internal */
   ControlGroup _findContainer(List<String> path) {
     path.removeLast();
     return ListWrapper.isEmpty(path)

--- a/lib/src/common/forms/directives/ng_form_control.dart
+++ b/lib/src/common/forms/directives/ng_form_control.dart
@@ -21,53 +21,48 @@ import "validators.dart" show ValidatorFn, AsyncValidatorFn;
 const formControlBinding =
     const Provider(NgControl, useExisting: NgFormControl);
 
-/**
- * Binds an existing [Control] to a DOM element.
- *
- * ### Example ([live demo](http://plnkr.co/edit/jcQlZ2tTh22BZZ2ucNAT?p=preview))
- *
- * In this example, we bind the control to an input element. When the value of the input element
- * changes, the value of the control will reflect that change. Likewise, if the value of the
- * control changes, the input element reflects that change.
- *
- *  ```typescript
- * @Component({
- *   selector: 'my-app',
- *   template: `
- *     <div>
- *       <h2>NgFormControl Example</h2>
- *       <form>
- *         <p>Element with existing control: <input type="text"
- * [ngFormControl]="loginControl"></p>
- *         <p>Value of existing control: {{loginControl.value}}</p>
- *       </form>
- *     </div>
- *   `,
- *   directives: [CORE_DIRECTIVES, FORM_DIRECTIVES]
- * })
- * export class App {
- *   loginControl: Control = new Control('');
- * }
- *  ```
- *
- * ### ngModel
- *
- * We can also use `ngModel` to bind a domain model to the form.
- *
- * ### Example ([live demo](http://plnkr.co/edit/yHMLuHO7DNgT8XvtjTDH?p=preview))
- *
- *  ```typescript
- * @Component({
- *      selector: "login-comp",
- *      directives: [FORM_DIRECTIVES],
- *      template: "<input type='text' [ngFormControl]='loginControl' [(ngModel)]='login'>"
- *      })
- * class LoginComp {
- *  loginControl: Control = new Control('');
- *  login:string;
- * }
- *  ```
- */
+/// Binds an existing [Control] to a DOM element.
+///
+/// ### Example
+///
+/// In this example, we bind the control to an input element. When the value of the input element
+/// changes, the value of the control will reflect that change. Likewise, if the value of the
+/// control changes, the input element reflects that change.
+///
+///     @Component(
+///       selector: 'my-app',
+///       template: '''
+///         <div>
+///           <h2>NgFormControl Example</h2>
+///           <form>
+///             <p>Element with existing control:
+///               <input type="text" [ngFormControl]="loginControl">
+///             </p>
+///             <p>Value of existing control: {{loginControl.value}}</p>
+///           </form>
+///         </div>
+///       ''',
+///       directives: const [CORE_DIRECTIVES, FORM_DIRECTIVES]
+///     )
+///     class App {
+///       Control loginControl = new Control('');
+///     }
+///
+/// ### ngModel
+///
+/// We can also use `ngModel` to bind a domain model to the form.
+///
+/// ### Example
+///
+///     @Component(
+///          selector: "login-comp",
+///          directives: const [FORM_DIRECTIVES],
+///          template: "<input type='text' [ngFormControl]='loginControl' [(ngModel)]='login'>"
+///          )
+///     class LoginComp {
+///      Control loginControl = new Control('');
+///      String login;
+///     }
 @Directive(
     selector: "[ngFormControl]",
     providers: const [formControlBinding],

--- a/lib/src/common/forms/directives/ng_form_control.dart
+++ b/lib/src/common/forms/directives/ng_form_control.dart
@@ -29,24 +29,26 @@ const formControlBinding =
 /// changes, the value of the control will reflect that change. Likewise, if the value of the
 /// control changes, the input element reflects that change.
 ///
-///     @Component(
-///       selector: 'my-app',
-///       template: '''
-///         <div>
-///           <h2>NgFormControl Example</h2>
-///           <form>
-///             <p>Element with existing control:
-///               <input type="text" [ngFormControl]="loginControl">
-///             </p>
-///             <p>Value of existing control: {{loginControl.value}}</p>
-///           </form>
-///         </div>
-///       ''',
-///       directives: const [CORE_DIRECTIVES, FORM_DIRECTIVES]
-///     )
-///     class App {
-///       Control loginControl = new Control('');
-///     }
+/// ```dart
+/// @Component(
+///   selector: 'my-app',
+///   template: '''
+///     <div>
+///       <h2>NgFormControl Example</h2>
+///       <form>
+///         <p>Element with existing control:
+///           <input type="text" [ngFormControl]="loginControl">
+///         </p>
+///         <p>Value of existing control: {{loginControl.value}}</p>
+///       </form>
+///     </div>
+///   ''',
+///   directives: const [CORE_DIRECTIVES, FORM_DIRECTIVES]
+/// )
+/// class App {
+///   Control loginControl = new Control('');
+/// }
+/// ```
 ///
 /// ### ngModel
 ///
@@ -54,15 +56,17 @@ const formControlBinding =
 ///
 /// ### Example
 ///
-///     @Component(
-///          selector: "login-comp",
-///          directives: const [FORM_DIRECTIVES],
-///          template: "<input type='text' [ngFormControl]='loginControl' [(ngModel)]='login'>"
-///          )
-///     class LoginComp {
-///      Control loginControl = new Control('');
-///      String login;
-///     }
+/// ```dart
+/// @Component(
+///      selector: "login-comp",
+///      directives: const [FORM_DIRECTIVES],
+///      template: "<input type='text' [ngFormControl]='loginControl' [(ngModel)]='login'>"
+///      )
+/// class LoginComp {
+///  Control loginControl = new Control('');
+///  String login;
+/// }
+/// ```
 @Directive(
     selector: "[ngFormControl]",
     providers: const [formControlBinding],

--- a/lib/src/common/forms/directives/ng_form_model.dart
+++ b/lib/src/common/forms/directives/ng_form_model.dart
@@ -30,65 +30,69 @@ const formDirectiveProvider =
 /// In this example, we bind the control group to the form element, and we bind
 /// the login and password controls to the login and password elements.
 ///
-///     @Component(
-///       selector: 'my-app',
-///       template: '''
-///         <div>
-///           <h2>NgFormModel Example</h2>
-///           <form [ngFormModel]="loginForm">
-///             <p>Login: <input type="text" ngControl="login"></p>
-///             <p>Password: <input type="password" ngControl="password"></p>
-///           </form>
-///           <p>Value:</p>
-///           <pre>{{value}}</pre>
-///         </div>
-///       ''',
-///       directives: const [FORM_DIRECTIVES]
-///     })
-///     class App {
-///       ControlGroup loginForm;
+/// ```dart
+/// @Component(
+///   selector: 'my-app',
+///   template: '''
+///     <div>
+///       <h2>NgFormModel Example</h2>
+///       <form [ngFormModel]="loginForm">
+///         <p>Login: <input type="text" ngControl="login"></p>
+///         <p>Password: <input type="password" ngControl="password"></p>
+///       </form>
+///       <p>Value:</p>
+///       <pre>{{value}}</pre>
+///     </div>
+///   ''',
+///   directives: const [FORM_DIRECTIVES]
+/// })
+/// class App {
+///   ControlGroup loginForm;
 ///
-///       App() {
-///         loginForm = new ControlGroup({
-///           login: new Control(""),
-///           password: new Control("")
-///         });
-///       }
+///   App() {
+///     loginForm = new ControlGroup({
+///       login: new Control(""),
+///       password: new Control("")
+///     });
+///   }
 ///
-///       String get value {
-///         return JSON.encode(loginForm.value);
-///       }
-///     }
+///   String get value {
+///     return JSON.encode(loginForm.value);
+///   }
+/// }
+/// ```
 ///
 /// We can also use ngModel to bind a domain model to the form.
 ///
-///     @Component(
-///          selector: "login-comp",
-///          directives: const [FORM_DIRECTIVES],
-///          template: '''
-///            <form [ngFormModel]='loginForm'>
-///              Login <input type='text' ngControl='login' [(ngModel)]='credentials.login'>
-///              Password <input type='password' ngControl='password'
-///                              [(ngModel)]='credentials.password'>
-///              <button (click)="onLogin()">Login</button>
-///            </form>'''
-///          )
-///     class LoginComp {
-///      credentials: {login: string, password: string};
-///      ControlGroup loginForm;
+/// ```dart
+/// @Component(
+///      selector: "login-comp",
+///      directives: const [FORM_DIRECTIVES],
+///      template: '''
+///        <form [ngFormModel]='loginForm'>
+///          Login <input type='text' ngControl='login' [(ngModel)]='credentials.login'>
+///          Password <input type='password' ngControl='password'
+///                          [(ngModel)]='credentials.password'>
+///          <button (click)="onLogin()">Login</button>
+///        </form>'''
+///      )
+/// class LoginComp {
+///  credentials: {login: string, password: string};
+///  ControlGroup loginForm;
 ///
-///      LoginComp() {
-///        loginForm = new ControlGroup({
-///          login: new Control(""),
-///          password: new Control("")
-///        });
-///      }
+///  LoginComp() {
+///    loginForm = new ControlGroup({
+///      login: new Control(""),
+///      password: new Control("")
+///    });
+///  }
 ///
-///      void onLogin() {
-///        // credentials.login === 'some login'
-///        // credentials.password === 'some password'
-///      }
-///     }
+///  void onLogin() {
+///    // credentials.login === 'some login'
+///    // credentials.password === 'some password'
+///  }
+/// }
+/// ```
 @Directive(
     selector: "[ngFormModel]",
     providers: const [formDirectiveProvider],

--- a/lib/src/common/forms/directives/ng_form_model.dart
+++ b/lib/src/common/forms/directives/ng_form_model.dart
@@ -23,78 +23,72 @@ import "shared.dart"
 const formDirectiveProvider =
     const Provider(ControlContainer, useExisting: NgFormModel);
 
-/**
- * Binds an existing control group to a DOM element.
- *
- * ### Example ([live demo](http://plnkr.co/edit/jqrVirudY8anJxTMUjTP?p=preview))
- *
- * In this example, we bind the control group to the form element, and we bind the login and
- * password controls to the login and password elements.
- *
- *  ```typescript
- * @Component({
- *   selector: 'my-app',
- *   template: `
- *     <div>
- *       <h2>NgFormModel Example</h2>
- *       <form [ngFormModel]="loginForm">
- *         <p>Login: <input type="text" ngControl="login"></p>
- *         <p>Password: <input type="password" ngControl="password"></p>
- *       </form>
- *       <p>Value:</p>
- *       <pre>{{value}}</pre>
- *     </div>
- *   `,
- *   directives: [FORM_DIRECTIVES]
- * })
- * export class App {
- *   loginForm: ControlGroup;
- *
- *   constructor() {
- *     this.loginForm = new ControlGroup({
- *       login: new Control(""),
- *       password: new Control("")
- *     });
- *   }
- *
- *   get value(): string {
- *     return JSON.stringify(this.loginForm.value, null, 2);
- *   }
- * }
- *  ```
- *
- * We can also use ngModel to bind a domain model to the form.
- *
- *  ```typescript
- * @Component({
- *      selector: "login-comp",
- *      directives: [FORM_DIRECTIVES],
- *      template: `
- *        <form [ngFormModel]='loginForm'>
- *          Login <input type='text' ngControl='login' [(ngModel)]='credentials.login'>
- *          Password <input type='password' ngControl='password'
- *                          [(ngModel)]='credentials.password'>
- *          <button (click)="onLogin()">Login</button>
- *        </form>`
- *      })
- * class LoginComp {
- *  credentials: {login: string, password: string};
- *  loginForm: ControlGroup;
- *
- *  constructor() {
- *    this.loginForm = new ControlGroup({
- *      login: new Control(""),
- *      password: new Control("")
- *    });
- *  }
- *
- *  onLogin(): void {
- *    // this.credentials.login === 'some login'
- *    // this.credentials.password === 'some password'
- *  }
- * }
- *  ```
- */
+/// Binds an existing control group to a DOM element.
+///
+/// ### Example
+///
+/// In this example, we bind the control group to the form element, and we bind
+/// the login and password controls to the login and password elements.
+///
+///     @Component(
+///       selector: 'my-app',
+///       template: '''
+///         <div>
+///           <h2>NgFormModel Example</h2>
+///           <form [ngFormModel]="loginForm">
+///             <p>Login: <input type="text" ngControl="login"></p>
+///             <p>Password: <input type="password" ngControl="password"></p>
+///           </form>
+///           <p>Value:</p>
+///           <pre>{{value}}</pre>
+///         </div>
+///       ''',
+///       directives: const [FORM_DIRECTIVES]
+///     })
+///     class App {
+///       ControlGroup loginForm;
+///
+///       App() {
+///         loginForm = new ControlGroup({
+///           login: new Control(""),
+///           password: new Control("")
+///         });
+///       }
+///
+///       String get value {
+///         return JSON.encode(loginForm.value);
+///       }
+///     }
+///
+/// We can also use ngModel to bind a domain model to the form.
+///
+///     @Component(
+///          selector: "login-comp",
+///          directives: const [FORM_DIRECTIVES],
+///          template: '''
+///            <form [ngFormModel]='loginForm'>
+///              Login <input type='text' ngControl='login' [(ngModel)]='credentials.login'>
+///              Password <input type='password' ngControl='password'
+///                              [(ngModel)]='credentials.password'>
+///              <button (click)="onLogin()">Login</button>
+///            </form>'''
+///          )
+///     class LoginComp {
+///      credentials: {login: string, password: string};
+///      ControlGroup loginForm;
+///
+///      LoginComp() {
+///        loginForm = new ControlGroup({
+///          login: new Control(""),
+///          password: new Control("")
+///        });
+///      }
+///
+///      void onLogin() {
+///        // credentials.login === 'some login'
+///        // credentials.password === 'some password'
+///      }
+///     }
 @Directive(
     selector: "[ngFormModel]",
     providers: const [formDirectiveProvider],
@@ -174,7 +168,6 @@ class NgFormModel extends ControlContainer implements Form, OnChanges {
     return false;
   }
 
-  /** @internal */
   _updateDomValue() {
     this.directives.forEach((dir) {
       dynamic ctrl = this.form.find(dir.path);

--- a/lib/src/common/forms/directives/ng_model.dart
+++ b/lib/src/common/forms/directives/ng_model.dart
@@ -28,14 +28,16 @@ const formControlBinding = const Provider(NgControl, useExisting: NgModel);
 ///
 /// ### Example:
 ///
-///     @Component(
-///          selector: "search-comp",
-///          directives: const [FORM_DIRECTIVES],
-///          template: '<input type="text" [(ngModel)]="searchQuery">'
-///          )
-///     class SearchComp {
-///      String searchQuery;
-///     }
+/// ```dart
+/// @Component(
+///      selector: "search-comp",
+///      directives: const [FORM_DIRECTIVES],
+///      template: '<input type="text" [(ngModel)]="searchQuery">'
+///      )
+/// class SearchComp {
+///  String searchQuery;
+/// }
+/// ```
 @Directive(
     selector: "[ngModel]:not([ngControl]):not([ngFormControl])",
     providers: const [formControlBinding],

--- a/lib/src/common/forms/directives/ng_model.dart
+++ b/lib/src/common/forms/directives/ng_model.dart
@@ -19,27 +19,23 @@ import "validators.dart" show ValidatorFn, AsyncValidatorFn;
 
 const formControlBinding = const Provider(NgControl, useExisting: NgModel);
 
-/**
- * Binds a domain model to a form control.
- *
- * ### Usage
- *
- * `ngModel` binds an existing domain model to a form control. For a
- * two-way binding, use `[(ngModel)]` to ensure the model updates in
- * both directions.
- *
- * ### Example ([live demo](http://plnkr.co/edit/R3UX5qDaUqFO2VYR0UzH?p=preview))
- *  ```typescript
- * @Component({
- *      selector: "search-comp",
- *      directives: [FORM_DIRECTIVES],
- *      template: `<input type='text' [(ngModel)]="searchQuery">`
- *      })
- * class SearchComp {
- *  searchQuery: string;
- * }
- *  ```
- */
+/// Binds a domain model to a form control.
+///
+/// ### Usage
+///
+/// `ngModel` binds an existing domain model to a form control. For a two-way
+/// binding, use `[(ngModel)]` to ensure the model updates in both directions.
+///
+/// ### Example:
+///
+///     @Component(
+///          selector: "search-comp",
+///          directives: const [FORM_DIRECTIVES],
+///          template: '<input type="text" [(ngModel)]="searchQuery">'
+///          )
+///     class SearchComp {
+///      String searchQuery;
+///     }
 @Directive(
     selector: "[ngModel]:not([ngControl]):not([ngFormControl])",
     providers: const [formControlBinding],
@@ -49,9 +45,7 @@ const formControlBinding = const Provider(NgControl, useExisting: NgModel);
 class NgModel extends NgControl implements OnChanges {
   List<dynamic> _validators;
   List<dynamic> _asyncValidators;
-  /** @internal */
   var _control = new Control();
-  /** @internal */
   var _added = false;
   var update = new EventEmitter(false);
   dynamic model;

--- a/lib/src/common/forms/directives/number_value_accessor.dart
+++ b/lib/src/common/forms/directives/number_value_accessor.dart
@@ -12,6 +12,7 @@ const NUMBER_VALUE_ACCESSOR = const Provider(NG_VALUE_ACCESSOR,
 /// [NgModel], [NgFormControl], and [NgControlName] directives.
 ///
 ///  ### Example
+///
 ///  <input type="number" [(ngModel)]="age">
 @Directive(
     selector:

--- a/lib/src/common/forms/directives/number_value_accessor.dart
+++ b/lib/src/common/forms/directives/number_value_accessor.dart
@@ -8,15 +8,11 @@ import "control_value_accessor.dart"
 const NUMBER_VALUE_ACCESSOR = const Provider(NG_VALUE_ACCESSOR,
     useExisting: NumberValueAccessor, multi: true);
 
-/**
- * The accessor for writing a number value and listening to changes that is used by the
- * [NgModel], [NgFormControl], and [NgControlName] directives.
- *
- *  ### Example
- *  ```
- *  <input type="number" [(ngModel)]="age">
- *  ```
- */
+/// The accessor for writing a number value and listening to changes that is used by the
+/// [NgModel], [NgFormControl], and [NgControlName] directives.
+///
+///  ### Example
+///  <input type="number" [(ngModel)]="age">
 @Directive(
     selector:
         "input[type=number][ngControl],input[type=number][ngFormControl],input[type=number][ngModel]",

--- a/lib/src/common/forms/directives/radio_control_value_accessor.dart
+++ b/lib/src/common/forms/directives/radio_control_value_accessor.dart
@@ -55,24 +55,21 @@ class RadioButtonState {
   RadioButtonState(this.checked, this.value) {}
 }
 
-/**
- * The accessor for writing a radio control value and listening to changes that is used by the
- * [NgModel], [NgFormControl], and [NgControlName] directives.
- *
- *  ### Example
- *  ```
- *  @Component({
- *    template: `
- *      <input type="radio" name="food" [(ngModel)]="foodChicken">
- *      <input type="radio" name="food" [(ngModel)]="foodFish">
- *    `
- *  })
- *  class FoodCmp {
- *    foodChicken = new RadioButtonState(true, "chicken");
- *    foodFish = new RadioButtonState(false, "fish");
- *  }
- *  ```
- */
+/// The accessor for writing a radio control value and listening to changes that
+/// is used by the [NgModel], [NgFormControl], and [NgControlName] directives.
+///
+/// ### Example
+///
+///     @Component(
+///       template: '''
+///         <input type="radio" name="food" [(ngModel)]="foodChicken">
+///         <input type="radio" name="food" [(ngModel)]="foodFish">
+///       '''
+///     )
+///     class FoodCmp {
+///       RadioButtonState foodChicken = new RadioButtonState(true, "chicken");
+///       RadioButtonState foodFish = new RadioButtonState(false, "fish");
+///     }
 @Directive(
     selector:
         "input[type=radio][ngControl],input[type=radio][ngFormControl],input[type=radio][ngModel]",
@@ -84,13 +81,10 @@ class RadioControlValueAccessor
   ElementRef _elementRef;
   RadioControlRegistry _registry;
   Injector _injector;
-  /** @internal */
   RadioButtonState _state;
-  /** @internal */
   NgControl _control;
   @Input()
   String name;
-  /** @internal */
   Function _fn;
   var onChange = () {};
   var onTouched = () {};

--- a/lib/src/common/forms/directives/radio_control_value_accessor.dart
+++ b/lib/src/common/forms/directives/radio_control_value_accessor.dart
@@ -60,16 +60,18 @@ class RadioButtonState {
 ///
 /// ### Example
 ///
-///     @Component(
-///       template: '''
-///         <input type="radio" name="food" [(ngModel)]="foodChicken">
-///         <input type="radio" name="food" [(ngModel)]="foodFish">
-///       '''
-///     )
-///     class FoodCmp {
-///       RadioButtonState foodChicken = new RadioButtonState(true, "chicken");
-///       RadioButtonState foodFish = new RadioButtonState(false, "fish");
-///     }
+/// ```dart
+/// @Component(
+///   template: '''
+///     <input type="radio" name="food" [(ngModel)]="foodChicken">
+///     <input type="radio" name="food" [(ngModel)]="foodFish">
+///   '''
+/// )
+/// class FoodCmp {
+///   RadioButtonState foodChicken = new RadioButtonState(true, "chicken");
+///   RadioButtonState foodFish = new RadioButtonState(false, "fish");
+/// }
+/// ```
 @Directive(
     selector:
         "input[type=radio][ngControl],input[type=radio][ngFormControl],input[type=radio][ngModel]",

--- a/lib/src/common/forms/directives/select_control_value_accessor.dart
+++ b/lib/src/common/forms/directives/select_control_value_accessor.dart
@@ -27,15 +27,13 @@ String _extractId(String valueString) {
   return valueString.split(":")[0];
 }
 
-/**
- * The accessor for writing a value and listening to changes on a select element.
- *
- * Note: We have to listen to the 'change' event because 'input' events aren't fired
- * for selects in Firefox and IE:
- * https://bugzilla.mozilla.org/show_bug.cgi?id=1024350
- * https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4660045/
- *
- */
+/// The accessor for writing a value and listening to changes on a select
+/// element.
+///
+/// Note: We have to listen to the 'change' event because 'input' events aren't
+/// fired for selects in Firefox and IE:
+/// https://bugzilla.mozilla.org/show_bug.cgi?id=1024350
+/// https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4660045
 @Directive(
     selector: "select[ngControl],select[ngFormControl],select[ngModel]",
     host: const {
@@ -49,9 +47,7 @@ class SelectControlValueAccessor implements ControlValueAccessor {
   Renderer _renderer;
   ElementRef _elementRef;
   dynamic value;
-  /** @internal */
   Map<String, dynamic> _optionMap = new Map<String, dynamic>();
-  /** @internal */
   num _idCounter = 0;
   var onChange = (dynamic _) {};
   var onTouched = () {};
@@ -73,12 +69,10 @@ class SelectControlValueAccessor implements ControlValueAccessor {
     this.onTouched = fn;
   }
 
-  /** @internal */
   String _registerOption() {
     return (this._idCounter++).toString();
   }
 
-  /** @internal */
   String _getOptionId(dynamic value) {
     for (var id in MapWrapper.keys(this._optionMap)) {
       if (looseIdentical(this._optionMap[id], value)) return id;
@@ -86,24 +80,19 @@ class SelectControlValueAccessor implements ControlValueAccessor {
     return null;
   }
 
-  /** @internal */
   dynamic _getOptionValue(String valueString) {
     var value = this._optionMap[_extractId(valueString)];
     return isPresent(value) ? value : valueString;
   }
 }
 
-/**
- * Marks `<option>` as dynamic, so Angular can be notified when options change.
- *
- * ### Example
- *
- * ```
- * <select ngControl="city">
- *   <option *ngFor="let c of cities" [value]="c"></option>
- * </select>
- * ```
- */
+/// Marks `<option>` as dynamic, so Angular can be notified when options change.
+///
+/// ### Example
+///
+///     <select ngControl="city">
+///       <option *ngFor="let c of cities" [value]="c"></option>
+///     </select>
 @Directive(selector: "option")
 class NgSelectOption implements OnDestroy {
   ElementRef _element;
@@ -128,7 +117,6 @@ class NgSelectOption implements OnDestroy {
     if (isPresent(this._select)) this._select.writeValue(this._select.value);
   }
 
-  /** @internal */
   void _setElementValue(String value) {
     this
         ._renderer

--- a/lib/src/common/forms/directives/validators.dart
+++ b/lib/src/common/forms/directives/validators.dart
@@ -9,15 +9,17 @@ import "../validators.dart" show Validators, NG_VALIDATORS;
 ///
 /// ## Usage
 ///
-///     @Directive(
-///       selector: '[custom-validator]',
-///       providers: const [provide(NG_VALIDATORS, {useExisting: CustomValidatorDirective, multi: true})]
-///     )
-///     class CustomValidatorDirective implements Validator {
-///       Map<String, dynamic> validate(Control c) {
-///         return {"custom": true};
-///       }
-///     }
+/// ```dart
+/// @Directive(
+///   selector: '[custom-validator]',
+///   providers: const [provide(NG_VALIDATORS, {useExisting: CustomValidatorDirective, multi: true})]
+/// )
+/// class CustomValidatorDirective implements Validator {
+///   Map<String, dynamic> validate(Control c) {
+///     return {"custom": true};
+///   }
+/// }
+/// ```
 abstract class Validator {
   Map<String, dynamic> validate(modelModule.AbstractControl c);
 }

--- a/lib/src/common/forms/directives/validators.dart
+++ b/lib/src/common/forms/directives/validators.dart
@@ -5,23 +5,19 @@ import "../model.dart" show AbstractControl;
 import "../model.dart" as modelModule;
 import "../validators.dart" show Validators, NG_VALIDATORS;
 
-/**
- * An interface that can be implemented by classes that can act as validators.
- *
- * ## Usage
- *
- * ```typescript
- * @Directive({
- *   selector: '[custom-validator]',
- *   providers: [provide(NG_VALIDATORS, {useExisting: CustomValidatorDirective, multi: true})]
- * })
- * class CustomValidatorDirective implements Validator {
- *   validate(c: Control): {[key: string]: any} {
- *     return {"custom": true};
- *   }
- * }
- * ```
- */
+/// An interface that can be implemented by classes that can act as validators.
+///
+/// ## Usage
+///
+///     @Directive(
+///       selector: '[custom-validator]',
+///       providers: const [provide(NG_VALIDATORS, {useExisting: CustomValidatorDirective, multi: true})]
+///     )
+///     class CustomValidatorDirective implements Validator {
+///       Map<String, dynamic> validate(Control c) {
+///         return {"custom": true};
+///       }
+///     }
 abstract class Validator {
   Map<String, dynamic> validate(modelModule.AbstractControl c);
 }
@@ -30,16 +26,12 @@ const REQUIRED = Validators.required;
 const REQUIRED_VALIDATOR =
     const Provider(NG_VALIDATORS, useValue: REQUIRED, multi: true);
 
-/**
- * A Directive that adds the `required` validator to any controls marked with the
- * `required` attribute, via the [NG_VALIDATORS] binding.
- *
- * ### Example
- *
- * ```
- * <input ngControl="fullName" required>
- * ```
- */
+/// A Directive that adds the `required` validator to any controls marked with
+/// the `required` attribute, via the [NG_VALIDATORS] binding.
+///
+/// ### Example
+///
+///     <input ngControl="fullName" required>
 @Directive(
     selector:
         "[required][ngControl],[required][ngFormControl],[required][ngModel]",
@@ -48,20 +40,14 @@ class RequiredValidator {}
 
 typedef Map<String, dynamic> ValidatorFn(AbstractControl c);
 typedef dynamic AsyncValidatorFn(AbstractControl c);
-/**
- * Provivder which adds [MinLengthValidator] to [NG_VALIDATORS].
- *
- * ## Example:
- *
- * {@example common/forms/ts/validators/validators.ts region='min'}
- */
+
+/// Provider which adds [MinLengthValidator] to [NG_VALIDATORS].
 const MIN_LENGTH_VALIDATOR =
     const Provider(NG_VALIDATORS, useExisting: MinLengthValidator, multi: true);
 
-/**
- * A directive which installs the [MinLengthValidator] for any `ngControl`,
- * `ngFormControl`, or control with `ngModel` that also has a `minlength` attribute.
- */
+/// A directive which installs the [MinLengthValidator] for any `ngControl`,
+/// `ngFormControl`, or control with `ngModel` that also has a `minlength`
+/// attribute.
 @Directive(
     selector:
         "[minlength][ngControl],[minlength][ngFormControl],[minlength][ngModel]",
@@ -77,20 +63,13 @@ class MinLengthValidator implements Validator {
   }
 }
 
-/**
- * Provider which adds [MaxLengthValidator] to [NG_VALIDATORS].
- *
- * ## Example:
- *
- * {@example common/forms/ts/validators/validators.ts region='max'}
- */
+/// Provider which adds [MaxLengthValidator] to [NG_VALIDATORS].
 const MAX_LENGTH_VALIDATOR =
     const Provider(NG_VALIDATORS, useExisting: MaxLengthValidator, multi: true);
 
-/**
- * A directive which installs the [MaxLengthValidator] for any `ngControl, `ngFormControl`,
- * or control with `ngModel` that also has a `maxlength` attribute.
- */
+/// A directive which installs the [MaxLengthValidator] for any `ngControl,
+/// `ngFormControl`, or control with `ngModel` that also has a `maxlength`
+/// attribute.
 @Directive(
     selector:
         "[maxlength][ngControl],[maxlength][ngFormControl],[maxlength][ngModel]",
@@ -106,18 +85,14 @@ class MaxLengthValidator implements Validator {
   }
 }
 
-/**
- * A Directive that adds the `pattern` validator to any controls marked with the
- * `pattern` attribute, via the [NG_VALIDATORS] binding. Uses attribute value
- * as the regex to validate Control value against.  Follows pattern attribute
- * semantics; i.e. regex must match entire Control value.
- *
- * ### Example
- *
- * ```
- * <input [ngControl]="fullName" pattern="[a-zA-Z ]*">
- * ```
- */
+/// A Directive that adds the `pattern` validator to any controls marked with
+/// the `pattern` attribute, via the [NG_VALIDATORS] binding. Uses attribute
+/// value as the regex to validate Control value against.  Follows pattern
+/// attribute semantics; i.e. regex must match entire Control value.
+///
+/// ### Example
+///
+///     <input [ngControl]="fullName" pattern="[a-zA-Z ]*">
 const PATTERN_VALIDATOR =
     const Provider(NG_VALIDATORS, useExisting: PatternValidator, multi: true);
 

--- a/lib/src/common/forms/form_builder.dart
+++ b/lib/src/common/forms/form_builder.dart
@@ -5,40 +5,42 @@ import "model.dart" as modelModule;
 
 /// Creates a form object from a user-specified configuration.
 ///
-///      @Component(
-///        selector: 'my-app',
-///        viewBindings: const [FORM_BINDINGS]
-///        template: '''
-///          <form [ngFormModel]="loginForm">
-///            <p>Login <input ngControl="login"></p>
-///            <div ngControlGroup="passwordRetry">
-///              <p>Password <input type="password" ngControl="password"></p>
-///              <p>Confirm password <input type="password"
-///                 ngControl="passwordConfirmation"></p>
-///            </div>
-///          </form>
-///          <h3>Form value:</h3>
-///          <pre>{{value}}</pre>
-///        ''',
-///        directives: const [FORM_DIRECTIVES]
-///      )
-///      class App {
-///        ControlGroup loginForm;
+/// ```dart
+/// @Component(
+///   selector: 'my-app',
+///   viewBindings: const [FORM_BINDINGS]
+///   template: '''
+///     <form [ngFormModel]="loginForm">
+///       <p>Login <input ngControl="login"></p>
+///       <div ngControlGroup="passwordRetry">
+///         <p>Password <input type="password" ngControl="password"></p>
+///         <p>Confirm password <input type="password"
+///            ngControl="passwordConfirmation"></p>
+///       </div>
+///     </form>
+///     <h3>Form value:</h3>
+///     <pre>{{value}}</pre>
+///   ''',
+///   directives: const [FORM_DIRECTIVES]
+/// )
+/// class App {
+///   ControlGroup loginForm;
 ///
-///        App(FormBuilder builder) {
-///          this.loginForm = builder.group({
-///            login: ["", Validators.required],
-///            passwordRetry: builder.group({
-///              password: ["", Validators.required],
-///              passwordConfirmation: ["", Validators.required, asyncValidator]
-///            })
-///          });
-///        }
+///   App(FormBuilder builder) {
+///     this.loginForm = builder.group({
+///       login: ["", Validators.required],
+///       passwordRetry: builder.group({
+///         password: ["", Validators.required],
+///         passwordConfirmation: ["", Validators.required, asyncValidator]
+///       })
+///     });
+///   }
 ///
-///        String get value {
-///          return JSON.encode(this.loginForm.value);
-///        }
-///      }
+///   String get value {
+///     return JSON.encode(this.loginForm.value);
+///   }
+/// }
+/// ```
 @Injectable()
 class FormBuilder {
   /// Construct a new [ControlGroup] with the given map of configuration.

--- a/lib/src/common/forms/form_builder.dart
+++ b/lib/src/common/forms/form_builder.dart
@@ -5,40 +5,40 @@ import "model.dart" as modelModule;
 
 /// Creates a form object from a user-specified configuration.
 ///
-/// @Component(
-///   selector: 'my-app',
-///   viewBindings: [FORM_BINDINGS]
-///   template: '''
-///     <form [ngFormModel]="loginForm">
-///       <p>Login <input ngControl="login"></p>
-///       <div ngControlGroup="passwordRetry">
-///         <p>Password <input type="password" ngControl="password"></p>
-///         <p>Confirm password <input type="password"
-///            ngControl="passwordConfirmation"></p>
-///       </div>
-///     </form>
-///     <h3>Form value:</h3>
-///     <pre>{{value}}</pre>
-///   ''',
-///   directives: const [FORM_DIRECTIVES]
-/// )
-/// class App {
-///   ControlGroup loginForm;
+///      @Component(
+///        selector: 'my-app',
+///        viewBindings: const [FORM_BINDINGS]
+///        template: '''
+///          <form [ngFormModel]="loginForm">
+///            <p>Login <input ngControl="login"></p>
+///            <div ngControlGroup="passwordRetry">
+///              <p>Password <input type="password" ngControl="password"></p>
+///              <p>Confirm password <input type="password"
+///                 ngControl="passwordConfirmation"></p>
+///            </div>
+///          </form>
+///          <h3>Form value:</h3>
+///          <pre>{{value}}</pre>
+///        ''',
+///        directives: const [FORM_DIRECTIVES]
+///      )
+///      class App {
+///        ControlGroup loginForm;
 ///
-///   App(FormBuilder builder) {
-///     this.loginForm = builder.group({
-///       login: ["", Validators.required],
-///       passwordRetry: builder.group({
-///         password: ["", Validators.required],
-///         passwordConfirmation: ["", Validators.required, asyncValidator]
-///       })
-///     });
-///   }
+///        App(FormBuilder builder) {
+///          this.loginForm = builder.group({
+///            login: ["", Validators.required],
+///            passwordRetry: builder.group({
+///              password: ["", Validators.required],
+///              passwordConfirmation: ["", Validators.required, asyncValidator]
+///            })
+///          });
+///        }
 ///
-///   String get value {
-///     return JSON.encode(this.loginForm.value);
-///   }
-/// }
+///        String get value {
+///          return JSON.encode(this.loginForm.value);
+///        }
+///      }
 @Injectable()
 class FormBuilder {
   /// Construct a new [ControlGroup] with the given map of configuration.

--- a/lib/src/common/forms/model.dart
+++ b/lib/src/common/forms/model.dart
@@ -183,17 +183,19 @@ abstract class AbstractControl {
   ///
   /// ## Usage
   ///
-  ///     Control login = new Control("someLogin");
-  ///     login.setErrors({
-  ///       "notUnique": true
-  ///     });
+  /// ```dart
+  /// Control login = new Control("someLogin");
+  /// login.setErrors({
+  ///   "notUnique": true
+  /// });
   ///
-  ///     expect(login.valid).toEqual(false);
-  ///     expect(login.errors).toEqual({"notUnique": true});
+  /// expect(login.valid).toEqual(false);
+  /// expect(login.errors).toEqual({"notUnique": true});
   ///
-  ///     login.updateValue("someOtherLogin");
+  /// login.updateValue("someOtherLogin");
   ///
-  ///     expect(login.valid).toEqual(true);
+  /// expect(login.valid).toEqual(true);
+  /// ```
   void setErrors(Map<String, dynamic> errors, {bool emitEvent}) {
     emitEvent = isPresent(emitEvent) ? emitEvent : true;
     this._errors = errors;

--- a/lib/src/common/forms/model.dart
+++ b/lib/src/common/forms/model.dart
@@ -9,18 +9,16 @@ import "package:angular2/src/facade/lang.dart"
 
 import "directives/validators.dart" show ValidatorFn, AsyncValidatorFn;
 
-/**
- * Indicates that a Control is valid, i.e. that no errors exist in the input value.
- */
+/// Indicates that a Control is valid, i.e. that no errors exist in the input
+/// value.
 const VALID = "VALID";
-/**
- * Indicates that a Control is invalid, i.e. that an error exists in the input value.
- */
+
+/// Indicates that a Control is invalid, i.e. that an error exists in the input
+/// value.
 const INVALID = "INVALID";
-/**
- * Indicates that a Control is pending, i.e. that async validation is occurring and
- * errors are not yet available for the input value.
- */
+
+/// Indicates that a Control is pending, i.e. that async validation is occurring
+/// and errors are not yet available for the input value.
 const PENDING = "PENDING";
 bool isControl(Object control) {
   return control is AbstractControl;
@@ -49,9 +47,6 @@ Stream<dynamic> _toStream(futureOrStream) {
   return futureOrStream is Future ? futureOrStream.asStream() : futureOrStream;
 }
 
-/**
- *
- */
 abstract class AbstractControl {
   ValidatorFn validator;
   AsyncValidatorFn asyncValidator;
@@ -179,29 +174,26 @@ abstract class AbstractControl {
     }
   }
 
-  /**
-   * Sets errors on a control.
-   *
-   * This is used when validations are run not automatically, but manually by the user.
-   *
-   * Calling `setErrors` will also update the validity of the parent control.
-   *
-   * ## Usage
-   *
-   * ```
-   * var login = new Control("someLogin");
-   * login.setErrors({
-   *   "notUnique": true
-   * });
-   *
-   * expect(login.valid).toEqual(false);
-   * expect(login.errors).toEqual({"notUnique": true});
-   *
-   * login.updateValue("someOtherLogin");
-   *
-   * expect(login.valid).toEqual(true);
-   * ```
-   */
+  /// Sets errors on a control.
+  ///
+  /// This is used when validations are run not automatically, but manually by
+  /// the user.
+  ///
+  /// Calling `setErrors` will also update the validity of the parent control.
+  ///
+  /// ## Usage
+  ///
+  ///     Control login = new Control("someLogin");
+  ///     login.setErrors({
+  ///       "notUnique": true
+  ///     });
+  ///
+  ///     expect(login.valid).toEqual(false);
+  ///     expect(login.errors).toEqual({"notUnique": true});
+  ///
+  ///     login.updateValue("someOtherLogin");
+  ///
+  ///     expect(login.valid).toEqual(true);
   void setErrors(Map<String, dynamic> errors, {bool emitEvent}) {
     emitEvent = isPresent(emitEvent) ? emitEvent : true;
     this._errors = errors;
@@ -241,7 +233,6 @@ abstract class AbstractControl {
     return x;
   }
 
-  /** @internal */
   void _updateControlsErrors() {
     this._status = this._calculateStatus();
     if (isPresent(this._parent)) {
@@ -249,7 +240,6 @@ abstract class AbstractControl {
     }
   }
 
-  /** @internal */
   _initObservables() {
     this._valueChanges = new EventEmitter();
     this._statusChanges = new EventEmitter();
@@ -262,53 +252,47 @@ abstract class AbstractControl {
     return VALID;
   }
 
-  /** @internal */
   void _updateValue();
-  /** @internal */
   bool _anyControlsHaveStatus(String status);
 }
 
-/**
- * Defines a part of a form that cannot be divided into other controls. `Control`s have values and
- * validation state, which is determined by an optional validation function.
- *
- * `Control` is one of the three fundamental building blocks used to define forms in Angular, along
- * with [ControlGroup] and [ControlArray].
- *
- * ## Usage
- *
- * By default, a `Control` is created for every `<input>` or other form component.
- * With [NgFormControl] or [NgFormModel] an existing [Control] can be
- * bound to a DOM element instead. This `Control` can be configured with a custom
- * validation function.
- *
- * ### Example ([live demo](http://plnkr.co/edit/23DESOpbNnBpBHZt1BR4?p=preview))
- */
+/// Defines a part of a form that cannot be divided into other controls.
+/// `Control`s have values and validation state, which is determined by an
+/// optional validation function.
+///
+/// `Control` is one of the three fundamental building blocks used to define
+/// forms in Angular, along with [ControlGroup] and [ControlArray].
+///
+/// ## Usage
+///
+/// By default, a `Control` is created for every `<input>` or other form
+/// component.
+/// With [NgFormControl] or [NgFormModel] an existing [Control] can be
+/// bound to a DOM element instead. This `Control` can be configured with a
+/// custom validation function.
 class Control extends AbstractControl {
-  /** @internal */
   Function _onChange;
   Control(
       [dynamic value = null,
       ValidatorFn validator = null,
       AsyncValidatorFn asyncValidator = null])
       : super(validator, asyncValidator) {
-    /* super call moved to initializer */;
+    //// super call moved to initializer */;
     this._value = value;
     this.updateValueAndValidity(onlySelf: true, emitEvent: false);
     this._initObservables();
   }
-  /**
-   * Set the value of the control to `value`.
-   *
-   * If `onlySelf` is `true`, this change will only affect the validation of this `Control`
-   * and not its parent component. If `emitEvent` is `true`, this change will cause a
-   * `valueChanges` event on the `Control` to be emitted. Both of these options default to
-   * `false`.
-   *
-   * If `emitModelToViewChange` is `true`, the view will be notified about the new value
-   * via an `onChange` event. This is the default behavior if `emitModelToViewChange` is not
-   * specified.
-   */
+
+  /// Set the value of the control to `value`.
+  ///
+  /// If `onlySelf` is `true`, this change will only affect the validation of
+  /// this `Control` and not its parent component. If `emitEvent` is `true`,
+  /// this change will cause a `valueChanges` event on the `Control` to be
+  /// emitted. Both of these options default to `false`.
+  ///
+  /// If `emitModelToViewChange` is `true`, the view will be notified about the
+  /// new value via an `onChange` event. This is the default behavior if
+  /// `emitModelToViewChange` is not specified.
   void updateValue(dynamic value,
       {bool onlySelf, bool emitEvent, bool emitModelToViewChange}) {
     emitModelToViewChange =
@@ -319,39 +303,28 @@ class Control extends AbstractControl {
     this.updateValueAndValidity(onlySelf: onlySelf, emitEvent: emitEvent);
   }
 
-  /**
-   * @internal
-   */
   _updateValue() {}
-  /**
-   * @internal
-   */
+
   bool _anyControlsHaveStatus(String status) {
     return false;
   }
 
-  /**
-   * Register a listener for change events.
-   */
+  /// Register a listener for change events.
   void registerOnChange(Function fn) {
     this._onChange = fn;
   }
 }
 
-/**
- * Defines a part of a form, of fixed length, that can contain other controls.
- *
- * A `ControlGroup` aggregates the values of each [Control] in the group.
- * The status of a `ControlGroup` depends on the status of its children.
- * If one of the controls in a group is invalid, the entire group is invalid.
- * Similarly, if a control changes its value, the entire group changes as well.
- *
- * `ControlGroup` is one of the three fundamental building blocks used to define forms in Angular,
- * along with [Control] and [ControlArray]. [ControlArray] can also contain other
- * controls, but is of variable length.
- *
- * ### Example ([live demo](http://plnkr.co/edit/23DESOpbNnBpBHZt1BR4?p=preview))
- */
+/// Defines a part of a form, of fixed length, that can contain other controls.
+///
+/// A `ControlGroup` aggregates the values of each [Control] in the group.
+/// The status of a `ControlGroup` depends on the status of its children.
+/// If one of the controls in a group is invalid, the entire group is invalid.
+/// Similarly, if a control changes its value, the entire group changes as well.
+///
+/// `ControlGroup` is one of the three fundamental building blocks used to
+/// define forms in Angular, along with [Control] and [ControlArray].
+/// [ControlArray] can also contain other controls, but is of variable length.
 class ControlGroup extends AbstractControl {
   Map<String, AbstractControl> controls;
   Map<String, bool> _optionals;
@@ -366,46 +339,35 @@ class ControlGroup extends AbstractControl {
     this._setParentForControls();
     this.updateValueAndValidity(onlySelf: true, emitEvent: false);
   }
-  /**
-   * Add a control to this group.
-   */
+  /// Add a control to this group.
   void addControl(String name, AbstractControl control) {
     this.controls[name] = control;
     control.setParent(this);
   }
 
-  /**
-   * Remove a control from this group.
-   */
+  /// Remove a control from this group.
   void removeControl(String name) {
     StringMapWrapper.delete(this.controls, name);
   }
 
-  /**
-   * Mark the named control as non-optional.
-   */
+  /// Mark the named control as non-optional.
   void include(String controlName) {
     StringMapWrapper.set(this._optionals, controlName, true);
     this.updateValueAndValidity();
   }
 
-  /**
-   * Mark the named control as optional.
-   */
+  /// Mark the named control as optional.
   void exclude(String controlName) {
     StringMapWrapper.set(this._optionals, controlName, false);
     this.updateValueAndValidity();
   }
 
-  /**
-   * Check whether there is a control with the given name in the group.
-   */
+  /// Check whether there is a control with the given name in the group.
   bool contains(String controlName) {
     var c = StringMapWrapper.contains(this.controls, controlName);
     return c && this._included(controlName);
   }
 
-  /** @internal */
   _setParentForControls() {
     StringMapWrapper.forEach(this.controls,
         (AbstractControl control, String name) {
@@ -413,12 +375,10 @@ class ControlGroup extends AbstractControl {
     });
   }
 
-  /** @internal */
   _updateValue() {
     this._value = this._reduceValue();
   }
 
-  /** @internal */
   bool _anyControlsHaveStatus(String status) {
     var res = false;
     StringMapWrapper.forEach(this.controls,
@@ -428,7 +388,6 @@ class ControlGroup extends AbstractControl {
     return res;
   }
 
-  /** @internal */
   _reduceValue() {
     return this._reduceChildren({}, (Map<String, AbstractControl> acc,
         AbstractControl control, String name) {
@@ -437,7 +396,6 @@ class ControlGroup extends AbstractControl {
     });
   }
 
-  /** @internal */
   _reduceChildren(dynamic initValue, Function fn) {
     var res = initValue;
     StringMapWrapper.forEach(this.controls,
@@ -449,35 +407,32 @@ class ControlGroup extends AbstractControl {
     return res;
   }
 
-  /** @internal */
   bool _included(String controlName) {
     var isOptional = StringMapWrapper.contains(this._optionals, controlName);
     return !isOptional || StringMapWrapper.get(this._optionals, controlName);
   }
 }
 
-/**
- * Defines a part of a form, of variable length, that can contain other controls.
- *
- * A `ControlArray` aggregates the values of each [Control] in the group.
- * The status of a `ControlArray` depends on the status of its children.
- * If one of the controls in a group is invalid, the entire array is invalid.
- * Similarly, if a control changes its value, the entire array changes as well.
- *
- * `ControlArray` is one of the three fundamental building blocks used to define forms in Angular,
- * along with [Control] and [ControlGroup]. [ControlGroup] can also contain
- * other controls, but is of fixed length.
- *
- * ## Adding or removing controls
- *
- * To change the controls in the array, use the `push`, `insert`, or `removeAt` methods
- * in `ControlArray` itself. These methods ensure the controls are properly tracked in the
- * form's hierarchy. Do not modify the array of `AbstractControl`s used to instantiate
- * the `ControlArray` directly, as that will result in strange and unexpected behavior such
- * as broken change detection.
- *
- * ### Example ([live demo](http://plnkr.co/edit/23DESOpbNnBpBHZt1BR4?p=preview))
- */
+/// Defines a part of a form, of variable length, that can contain other
+/// controls.
+///
+/// A `ControlArray` aggregates the values of each [Control] in the group.
+/// The status of a `ControlArray` depends on the status of its children.
+/// If one of the controls in a group is invalid, the entire array is invalid.
+/// Similarly, if a control changes its value, the entire array changes as well.
+///
+/// `ControlArray` is one of the three fundamental building blocks used to
+/// define forms in Angular, along with [Control] and [ControlGroup].
+/// [ControlGroup] can also contain other controls, but is of fixed length.
+///
+/// ## Adding or removing controls
+///
+/// To change the controls in the array, use the `push`, `insert`, or `removeAt`
+/// methods in `ControlArray` itself. These methods ensure the controls are
+/// properly tracked in the form's hierarchy. Do not modify the array of
+/// `AbstractControl`s used to instantiate the `ControlArray` directly, as that
+/// will result in strange and unexpected behavior such as broken change
+/// detection.
 class ControlArray extends AbstractControl {
   List<AbstractControl> controls;
   ControlArray(this.controls,
@@ -488,57 +443,45 @@ class ControlArray extends AbstractControl {
     this._setParentForControls();
     this.updateValueAndValidity(onlySelf: true, emitEvent: false);
   }
-  /**
-   * Get the [AbstractControl] at the given `index` in the array.
-   */
+
+  /// Get the [AbstractControl] at the given `index` in the list.
   AbstractControl at(num index) {
     return this.controls[index];
   }
 
-  /**
-   * Insert a new [AbstractControl] at the end of the array.
-   */
+  /// Insert a new [AbstractControl] at the end of the array.
   void push(AbstractControl control) {
     this.controls.add(control);
     control.setParent(this);
     this.updateValueAndValidity();
   }
 
-  /**
-   * Insert a new [AbstractControl] at the given `index` in the array.
-   */
+   /// Insert a new [AbstractControl] at the given `index` in the array.
   void insert(num index, AbstractControl control) {
     ListWrapper.insert(this.controls, index, control);
     control.setParent(this);
     this.updateValueAndValidity();
   }
 
-  /**
-   * Remove the control at the given `index` in the array.
-   */
+  /// Remove the control at the given `index` in the array.
   void removeAt(num index) {
     ListWrapper.removeAt(this.controls, index);
     this.updateValueAndValidity();
   }
 
-  /**
-   * Length of the control array.
-   */
+  /// Length of the control array.
   num get length {
     return this.controls.length;
   }
 
-  /** @internal */
   void _updateValue() {
     this._value = this.controls.map((control) => control.value).toList();
   }
 
-  /** @internal */
   bool _anyControlsHaveStatus(String status) {
     return this.controls.any((c) => c.status == status);
   }
 
-  /** @internal */
   void _setParentForControls() {
     this.controls.forEach((control) {
       control.setParent(this);

--- a/lib/src/common/forms/validators.dart
+++ b/lib/src/common/forms/validators.dart
@@ -8,42 +8,30 @@ import "package:angular2/src/facade/lang.dart"
 import "directives/validators.dart" show ValidatorFn, AsyncValidatorFn;
 import "model.dart" as modelModule;
 
-/**
- * Providers for validators to be used for [Control]s in a form.
- *
- * Provide this using `multi: true` to add validators.
- *
- * ### Example
- *
- * {@example core/forms/ts/ng_validators/ng_validators.ts region='ng_validators'}
- */
+///  Providers for validators to be used for [Control]s in a form.
+///
+///  Provide this using `multi: true` to add validators.
 const OpaqueToken NG_VALIDATORS = const OpaqueToken("NgValidators");
-/**
- * Providers for asynchronous validators to be used for [Control]s
- * in a form.
- *
- * Provide this using `multi: true` to add validators.
- *
- * See [NG_VALIDATORS] for more details.
- */
+
+///  Providers for asynchronous validators to be used for [Control]s
+///  in a form.
+///
+///  Provide this using `multi: true` to add validators.
+///
+///  See [NG_VALIDATORS] for more details.
 const OpaqueToken NG_ASYNC_VALIDATORS = const OpaqueToken("NgAsyncValidators");
 
-/**
- * Provides a set of validators used by form controls.
- *
- * A validator is a function that processes a [Control] or collection of
- * controls and returns a map of errors. A null map means that validation has passed.
- *
- * ### Example
- *
- * ```typescript
- * var loginControl = new Control("", Validators.required)
- * ```
- */
+
+///  Provides a set of validators used by form controls.
+///
+///  A validator is a function that processes a [Control] or collection of
+///  controls and returns a map of errors. A null map means that validation has passed.
+///
+///  ### Example
+///
+///     Control loginControl = new Control("", Validators.required)
 class Validators {
-  /**
-   * Validator that requires controls to have a non-empty value.
-   */
+  ///  Validator that requires controls to have a non-empty value.
   static Map<String, bool> required(modelModule.AbstractControl control) {
     return isBlank(control.value) ||
             (isString(control.value) && control.value == "")
@@ -51,9 +39,7 @@ class Validators {
         : null;
   }
 
-  /**
-   * Validator that requires controls to have a value of a minimum length.
-   */
+  ///  Validator that requires controls to have a value of a minimum length.
   static ValidatorFn minLength(num minLength) {
     return /* Map < String , dynamic > */ (modelModule
         .AbstractControl control) {
@@ -70,9 +56,7 @@ class Validators {
     };
   }
 
-  /**
-   * Validator that requires controls to have a value of a maximum length.
-   */
+  ///  Validator that requires controls to have a value of a maximum length.
   static ValidatorFn maxLength(num maxLength) {
     return /* Map < String , dynamic > */ (modelModule
         .AbstractControl control) {
@@ -89,9 +73,7 @@ class Validators {
     };
   }
 
-  /**
-   * Validator that requires a control to match a regex to its value.
-   */
+  ///  Validator that requires a control to match a regex to its value.
   static ValidatorFn pattern(String pattern) {
     return /* Map < String , dynamic > */ (modelModule
         .AbstractControl control) {
@@ -109,17 +91,13 @@ class Validators {
     };
   }
 
-  /**
-   * No-op validator.
-   */
+  ///  No-op validator.
   static Map<String, bool> nullValidator(modelModule.AbstractControl c) {
     return null;
   }
 
-  /**
-   * Compose multiple validators into a single function that returns the union
-   * of the individual error maps.
-   */
+  ///  Compose multiple validators into a single function that returns the union
+  ///  of the individual error maps.
   static ValidatorFn compose(List<ValidatorFn> validators) {
     if (isBlank(validators)) return null;
     var presentValidators = validators.where(isPresent).toList();

--- a/lib/src/common/forms/validators.dart
+++ b/lib/src/common/forms/validators.dart
@@ -29,7 +29,9 @@ const OpaqueToken NG_ASYNC_VALIDATORS = const OpaqueToken("NgAsyncValidators");
 ///
 ///  ### Example
 ///
-///     Control loginControl = new Control("", Validators.required)
+/// ```dart
+/// Control loginControl = new Control("", Validators.required)
+/// ```
 class Validators {
   ///  Validator that requires controls to have a non-empty value.
   static Map<String, bool> required(modelModule.AbstractControl control) {

--- a/lib/src/common/pipes.dart
+++ b/lib/src/common/pipes.dart
@@ -1,8 +1,4 @@
-/**
- * 
- * 
- * This module provides a set of common Pipes.
- */
+// This module provides a set of common Pipes.
 
 export "pipes/async_pipe.dart" show AsyncPipe;
 export "pipes/common_pipes.dart" show COMMON_PIPES;

--- a/lib/src/common/pipes/async_pipe.dart
+++ b/lib/src/common/pipes/async_pipe.dart
@@ -59,17 +59,12 @@ Future<dynamic> ___unused;
 @Pipe(name: "async", pure: false)
 @Injectable()
 class AsyncPipe implements OnDestroy {
-  /** @internal */
   Object _latestValue = null;
-  /** @internal */
   Object _latestReturnedValue = null;
-  /** @internal */
   Object _subscription = null;
-  /** @internal */
   dynamic /* Stream< dynamic > | Future< dynamic > | EventEmitter< dynamic > */ _obj =
       null;
   dynamic _strategy = null;
-  /** @internal */
   ChangeDetectorRef _ref;
   AsyncPipe(ChangeDetectorRef _ref) {
     this._ref = _ref;
@@ -101,7 +96,6 @@ class AsyncPipe implements OnDestroy {
     }
   }
 
-  /** @internal */
   void _subscribe(
       dynamic /* Stream< dynamic > | Future< dynamic > | EventEmitter< dynamic > */ obj) {
     this._obj = obj;
@@ -110,7 +104,6 @@ class AsyncPipe implements OnDestroy {
         obj, (Object value) => this._updateLatestValue(obj, value));
   }
 
-  /** @internal */
   dynamic _selectStrategy(
       dynamic /* Stream< dynamic > | Future< dynamic > | EventEmitter< dynamic > */ obj) {
     if (isPromise(obj)) {
@@ -122,7 +115,6 @@ class AsyncPipe implements OnDestroy {
     }
   }
 
-  /** @internal */
   void _dispose() {
     this._strategy.dispose(this._subscription);
     this._latestValue = null;
@@ -131,7 +123,6 @@ class AsyncPipe implements OnDestroy {
     this._obj = null;
   }
 
-  /** @internal */
   _updateLatestValue(dynamic async, Object value) {
     if (identical(async, this._obj)) {
       this._latestValue = value;

--- a/lib/src/common/pipes/common_pipes.dart
+++ b/lib/src/common/pipes/common_pipes.dart
@@ -1,8 +1,4 @@
-/**
- * 
- * 
- * This module provides a set of common Pipes.
- */
+// This module provides a set of common Pipes.
 
 import "async_pipe.dart" show AsyncPipe;
 import "date_pipe.dart" show DatePipe;
@@ -15,13 +11,11 @@ import "replace_pipe.dart" show ReplacePipe;
 import "slice_pipe.dart" show SlicePipe;
 import "uppercase_pipe.dart" show UpperCasePipe;
 
-/**
- * A collection of Angular core pipes that are likely to be used in each and every
- * application.
- *
- * This collection can be used to quickly enumerate all the built-in pipes in the `pipes`
- * property of the `@Component` decorator.
- */
+/// A collection of Angular core pipes that are likely to be used in each and
+/// every application.
+///
+/// This collection can be used to quickly enumerate all the built-in pipes in
+/// the `pipes` property of the `@Component` decorator.
 const COMMON_PIPES = const [
   AsyncPipe,
   UpperCasePipe,

--- a/lib/src/common/pipes/date_pipe.dart
+++ b/lib/src/common/pipes/date_pipe.dart
@@ -9,76 +9,72 @@ import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 // TODO: move to a global configurable location along with other i18n components.
 String defaultLocale = "en-US";
 
-/**
- * Formats a date value to a string based on the requested format.
- *
- * WARNINGS:
- * - this pipe is marked as pure hence it will not be re-evaluated when the input is mutated.
- *   Instead users should treat the date as an immutable object and change the reference when the
- *   pipe needs to re-run (this is to avoid reformatting the date on every change detection run
- *   which would be an expensive operation).
- * - this pipe uses the Internationalization API. Therefore it is only reliable in Chrome and Opera
- *   browsers.
- *
- * ## Usage
- *
- *     expression | date[:format]
- *
- * where `expression` is a date object or a number (milliseconds since UTC epoch) and
- * `format` indicates which date/time components to include:
- *
- *  | Component | Symbol | Short Form   | Long Form         | Numeric   | 2-digit   |
- *  |-----------|:------:|--------------|-------------------|-----------|-----------|
- *  | era       |   G    | G (AD)       | GGGG (Anno Domini)| -         | -         |
- *  | year      |   y    | -            | -                 | y (2015)  | yy (15)   |
- *  | month     |   M    | MMM (Sep)    | MMMM (September)  | M (9)     | MM (09)   |
- *  | day       |   d    | -            | -                 | d (3)     | dd (03)   |
- *  | weekday   |   E    | EEE (Sun)    | EEEE (Sunday)     | -         | -         |
- *  | hour      |   j    | -            | -                 | j (13)    | jj (13)   |
- *  | hour12    |   h    | -            | -                 | h (1 PM)  | hh (01 PM)|
- *  | hour24    |   H    | -            | -                 | H (13)    | HH (13)   |
- *  | minute    |   m    | -            | -                 | m (5)     | mm (05)   |
- *  | second    |   s    | -            | -                 | s (9)     | ss (09)   |
- *  | timezone  |   z    | -            | z (Pacific Standard Time)| -  | -         |
- *  | timezone  |   Z    | Z (GMT-8:00) | -                 | -         | -         |
- *
- * In javascript, only the components specified will be respected (not the ordering,
- * punctuations, ...) and details of the formatting will be dependent on the locale.
- * On the other hand in Dart version, you can also include quoted text as well as some extra
- * date/time components such as quarter. For more information see:
- * https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/intl/intl.DateFormat.
- *
- * `format` can also be one of the following predefined formats:
- *
- *  - `'medium'`: equivalent to `'yMMMdjms'` (e.g. Sep 3, 2010, 12:05:08 PM for en-US)
- *  - `'short'`: equivalent to `'yMdjm'` (e.g. 9/3/2010, 12:05 PM for en-US)
- *  - `'fullDate'`: equivalent to `'yMMMMEEEEd'` (e.g. Friday, September 3, 2010 for en-US)
- *  - `'longDate'`: equivalent to `'yMMMMd'` (e.g. September 3, 2010)
- *  - `'mediumDate'`: equivalent to `'yMMMd'` (e.g. Sep 3, 2010 for en-US)
- *  - `'shortDate'`: equivalent to `'yMd'` (e.g. 9/3/2010 for en-US)
- *  - `'mediumTime'`: equivalent to `'jms'` (e.g. 12:05:08 PM for en-US)
- *  - `'shortTime'`: equivalent to `'jm'` (e.g. 12:05 PM for en-US)
- *
- * Timezone of the formatted text will be the local system timezone of the end-users machine.
- *
- * ### Examples
- *
- * Assuming `dateObj` is (year: 2015, month: 6, day: 15, hour: 21, minute: 43, second: 11)
- * in the _local_ time and locale is 'en-US':
- *
- * ```
- *     {{ dateObj | date }}               // output is 'Jun 15, 2015'
- *     {{ dateObj | date:'medium' }}      // output is 'Jun 15, 2015, 9:43:11 PM'
- *     {{ dateObj | date:'shortTime' }}   // output is '9:43 PM'
- *     {{ dateObj | date:'mmss' }}        // output is '43:11'
- * ```
- *
- * {@example core/pipes/ts/date_pipe/date_pipe_example.ts region='DatePipe'}
- */
+/// Formats a date value to a string based on the requested format.
+///
+/// WARNINGS:
+/// - this pipe is marked as pure hence it will not be re-evaluated when the
+///   input is mutated. Instead users should treat the date as an immutable
+///   object and change the reference when the pipe needs to re-run (this is to
+///   avoid reformatting the date on every change detection run which would be
+///   an expensive operation).
+/// - this pipe uses the Internationalization API. Therefore it is only reliable
+///   in Chrome and Opera browsers.
+///
+/// ## Usage
+///
+///     expression | date[:format]
+///
+/// where `expression` is a date object or a number (milliseconds since UTC
+/// epoch) and `format` indicates which date/time components to include:
+///
+///  | Component | Symbol | Short Form   | Long Form         | Numeric   | 2-digit   |
+///  |-----------|:------:|--------------|-------------------|-----------|-----------|
+///  | era       |   G    | G (AD)       | GGGG (Anno Domini)| -         | -         |
+///  | year      |   y    | -            | -                 | y (2015)  | yy (15)   |
+///  | month     |   M    | MMM (Sep)    | MMMM (September)  | M (9)     | MM (09)   |
+///  | day       |   d    | -            | -                 | d (3)     | dd (03)   |
+///  | weekday   |   E    | EEE (Sun)    | EEEE (Sunday)     | -         | -         |
+///  | hour      |   j    | -            | -                 | j (13)    | jj (13)   |
+///  | hour12    |   h    | -            | -                 | h (1 PM)  | hh (01 PM)|
+///  | hour24    |   H    | -            | -                 | H (13)    | HH (13)   |
+///  | minute    |   m    | -            | -                 | m (5)     | mm (05)   |
+///  | second    |   s    | -            | -                 | s (9)     | ss (09)   |
+///  | timezone  |   z    | -            | z (Pacific Standard Time)| -  | -         |
+///  | timezone  |   Z    | Z (GMT-8:00) | -                 | -         | -         |
+///
+/// In javascript, only the components specified will be respected (not the
+/// ordering, punctuations, ...) and details of the formatting will be dependent
+/// on the locale.
+/// On the other hand in Dart version, you can also include quoted text as well
+/// as some extra date/time components such as quarter. For more information see:
+/// https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/intl/intl.DateFormat.
+///
+/// `format` can also be one of the following predefined formats:
+///
+///  - `'medium'`: equivalent to `'yMMMdjms'` (e.g. Sep 3, 2010, 12:05:08 PM for en-US)
+///  - `'short'`: equivalent to `'yMdjm'` (e.g. 9/3/2010, 12:05 PM for en-US)
+///  - `'fullDate'`: equivalent to `'yMMMMEEEEd'` (e.g. Friday, September 3, 2010 for en-US)
+///  - `'longDate'`: equivalent to `'yMMMMd'` (e.g. September 3, 2010)
+///  - `'mediumDate'`: equivalent to `'yMMMd'` (e.g. Sep 3, 2010 for en-US)
+///  - `'shortDate'`: equivalent to `'yMd'` (e.g. 9/3/2010 for en-US)
+///  - `'mediumTime'`: equivalent to `'jms'` (e.g. 12:05:08 PM for en-US)
+///  - `'shortTime'`: equivalent to `'jm'` (e.g. 12:05 PM for en-US)
+///
+/// Timezone of the formatted text will be the local system timezone of the
+/// end-users machine.
+///
+/// ### Examples
+///
+/// Assuming `dateObj` is (year: 2015, month: 6, day: 15, hour: 21, minute: 43,
+/// second: 11) in the _local_ time and locale is 'en-US':
+///
+///     {{ dateObj | date }}             // output is 'Jun 15, 2015'
+///     {{ dateObj | date:'medium' }}    // output is 'Jun 15, 2015, 9:43:11 PM'
+///     {{ dateObj | date:'shortTime' }} // output is '9:43 PM'
+///     {{ dateObj | date:'mmss' }}      // output is '43:11'
 @Pipe(name: "date", pure: true)
 @Injectable()
 class DatePipe implements PipeTransform {
-  /** @internal */
   static final Map<String, String> _ALIASES = {
     "medium": "yMMMdjms",
     "short": "yMdjm",

--- a/lib/src/common/pipes/i18n_plural_pipe.dart
+++ b/lib/src/common/pipes/i18n_plural_pipe.dart
@@ -6,37 +6,32 @@ import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 
 RegExp interpolationExp = RegExpWrapper.create("#");
 
-/**
- *
- *  Maps a value to a string that pluralizes the value properly.
- *
- *  ## Usage
- *
- *  expression | i18nPlural:mapping
- *
- *  where `expression` is a number and `mapping` is an object that indicates the proper text for
- *  when the `expression` evaluates to 0, 1, or some other number.  You can interpolate the actual
- *  value into the text using the `#` sign.
- *
- *  ## Example
- *
- *  ```
- *  <div>
- *    {{ messages.length | i18nPlural: messageMapping }}
- *  </div>
- *
- *  class MyApp {
- *    messages: any[];
- *    messageMapping: any = {
- *      '=0': 'No messages.',
- *      '=1': 'One message.',
- *      'other': '# messages.'
- *    }
- *    ...
- *  }
- *  ```
- *
- */
+/// Maps a value to a string that pluralizes the value properly.
+///
+/// ## Usage
+///
+/// expression | i18nPlural:mapping
+///
+/// where `expression` is a number and `mapping` is an object that indicates the
+/// proper text for when the `expression` evaluates to 0, 1, or some other
+/// number.  You can interpolate the actual value into the text using the `#`
+/// sign.
+///
+/// ## Example
+///
+///     <div>
+///       {{ messages.length | i18nPlural: messageMapping }}
+///     </div>
+///
+///     class MyApp {
+///       List messages;
+///       dynamic messageMapping = {
+///         '=0': 'No messages.',
+///         '=1': 'One message.',
+///         'other': '# messages.'
+///       }
+///       ...
+///     }
 @Pipe(name: "i18nPlural", pure: true)
 @Injectable()
 class I18nPluralPipe implements PipeTransform {

--- a/lib/src/common/pipes/i18n_plural_pipe.dart
+++ b/lib/src/common/pipes/i18n_plural_pipe.dart
@@ -19,19 +19,21 @@ RegExp interpolationExp = RegExpWrapper.create("#");
 ///
 /// ## Example
 ///
-///     <div>
-///       {{ messages.length | i18nPlural: messageMapping }}
-///     </div>
+/// ```dart
+/// <div>
+///   {{ messages.length | i18nPlural: messageMapping }}
+/// </div>
 ///
-///     class MyApp {
-///       List messages;
-///       dynamic messageMapping = {
-///         '=0': 'No messages.',
-///         '=1': 'One message.',
-///         'other': '# messages.'
-///       }
-///       ...
-///     }
+/// class MyApp {
+///   List messages;
+///   dynamic messageMapping = {
+///     '=0': 'No messages.',
+///     '=1': 'One message.',
+///     'other': '# messages.'
+///   }
+///   ...
+/// }
+/// ```
 @Pipe(name: "i18nPlural", pure: true)
 @Injectable()
 class I18nPluralPipe implements PipeTransform {

--- a/lib/src/common/pipes/i18n_select_pipe.dart
+++ b/lib/src/common/pipes/i18n_select_pipe.dart
@@ -16,19 +16,21 @@ import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 ///
 /// ## Example
 ///
-///     <div>
-///       {{ gender | i18nSelect: inviteMap }}
-///     </div>
+/// ```dart
+/// <div>
+///   {{ gender | i18nSelect: inviteMap }}
+/// </div>
 ///
-///     class MyApp {
-///       String gender = 'male';
-///       dynamic inviteMap = {
-///         'male': 'Invite her.',
-///         'female': 'Invite him.',
-///         'other': 'Invite them.'
-///       }
-///       ...
-///     }
+/// class MyApp {
+///   String gender = 'male';
+///   dynamic inviteMap = {
+///     'male': 'Invite her.',
+///     'female': 'Invite him.',
+///     'other': 'Invite them.'
+///   }
+///   ...
+/// }
+/// ```
 @Pipe(name: "i18nSelect", pure: true)
 @Injectable()
 class I18nSelectPipe implements PipeTransform {

--- a/lib/src/common/pipes/i18n_select_pipe.dart
+++ b/lib/src/common/pipes/i18n_select_pipe.dart
@@ -4,35 +4,31 @@ import "package:angular2/src/facade/lang.dart" show isStringMap;
 
 import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 
-/**
- *
- *  Generic selector that displays the string that matches the current value.
- *
- *  ## Usage
- *
- *  expression | i18nSelect:mapping
- *
- *  where `mapping` is an object that indicates the text that should be displayed
- *  for different values of the provided `expression`.
- *
- *  ## Example
- *
- *  ```
- *  <div>
- *    {{ gender | i18nSelect: inviteMap }}
- *  </div>
- *
- *  class MyApp {
- *    gender: string = 'male';
- *    inviteMap: any = {
- *      'male': 'Invite her.',
- *      'female': 'Invite him.',
- *      'other': 'Invite them.'
- *    }
- *    ...
- *  }
- *  ```
- */
+///
+/// Generic selector that displays the string that matches the current value.
+///
+/// ## Usage
+///
+/// expression | i18nSelect:mapping
+///
+/// where `mapping` is an object that indicates the text that should be displayed
+/// for different values of the provided `expression`.
+///
+/// ## Example
+///
+///     <div>
+///       {{ gender | i18nSelect: inviteMap }}
+///     </div>
+///
+///     class MyApp {
+///       String gender = 'male';
+///       dynamic inviteMap = {
+///         'male': 'Invite her.',
+///         'female': 'Invite him.',
+///         'other': 'Invite them.'
+///       }
+///       ...
+///     }
 @Pipe(name: "i18nSelect", pure: true)
 @Injectable()
 class I18nSelectPipe implements PipeTransform {

--- a/lib/src/common/pipes/json_pipe.dart
+++ b/lib/src/common/pipes/json_pipe.dart
@@ -1,12 +1,7 @@
 import "package:angular2/core.dart" show Injectable, PipeTransform, Pipe;
 import "package:angular2/src/facade/lang.dart" show Json;
 
-/**
- * Transforms any input value using `JSON.stringify`. Useful for debugging.
- *
- * ### Example
- * {@example core/pipes/ts/json_pipe/json_pipe_example.ts region='JsonPipe'}
- */
+/// Transforms any input value using `JSON.encode`. Useful for debugging.
 @Pipe(name: "json", pure: false)
 @Injectable()
 class JsonPipe implements PipeTransform {

--- a/lib/src/common/pipes/lowercase_pipe.dart
+++ b/lib/src/common/pipes/lowercase_pipe.dart
@@ -3,13 +3,7 @@ import "package:angular2/src/facade/lang.dart" show isString, isBlank;
 
 import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 
-/**
- * Transforms text to lowercase.
- *
- * ### Example
- *
- * {@example core/pipes/ts/lowerupper_pipe/lowerupper_pipe_example.ts region='LowerUpperPipe'}
- */
+/// Transforms text to lowercase.
 @Pipe(name: "lowercase")
 @Injectable()
 class LowerCasePipe implements PipeTransform {

--- a/lib/src/common/pipes/number_pipe.dart
+++ b/lib/src/common/pipes/number_pipe.dart
@@ -10,12 +10,9 @@ import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 String defaultLocale = "en-US";
 var _re = RegExpWrapper.create("^(\\d+)?\\.((\\d+)(\\-(\\d+))?)?\$");
 
-/**
- * Internal base class for numeric pipes.
- */
+/// Internal base class for numeric pipes.
 @Injectable()
 class NumberPipe {
-  /** @internal */
   static String _format(num value, NumberFormatStyle style, String digits,
       [String currency = null, bool currencyAsSymbol = false]) {
     if (isBlank(value)) return null;
@@ -50,32 +47,26 @@ class NumberPipe {
   const NumberPipe();
 }
 
-/**
- * WARNING: this pipe uses the Internationalization API.
- * Therefore it is only reliable in Chrome and Opera browsers.
- *
- * Formats a number as local text. i.e. group sizing and separator and other locale-specific
- * configurations are based on the active locale.
- *
- * ### Usage
- *
- *     expression | number[:digitInfo]
- *
- * where `expression` is a number and `digitInfo` has the following format:
- *
- *     {minIntegerDigits}.{minFractionDigits}-{maxFractionDigits}
- *
- * - minIntegerDigits is the minimum number of integer digits to use. Defaults to 1.
- * - minFractionDigits is the minimum number of digits after fraction. Defaults to 0.
- * - maxFractionDigits is the maximum number of digits after fraction. Defaults to 3.
- *
- * For more information on the acceptable range for each of these numbers and other
- * details see your native internationalization library.
- *
- * ### Example
- *
- * {@example core/pipes/ts/number_pipe/number_pipe_example.ts region='NumberPipe'}
- */
+/// WARNING: this pipe uses the Internationalization API.
+/// Therefore it is only reliable in Chrome and Opera browsers.
+///
+/// Formats a number as local text. i.e. group sizing and separator and other locale-specific
+/// configurations are based on the active locale.
+///
+/// ### Usage
+///
+///     expression | number[:digitInfo]
+///
+/// where `expression` is a number and `digitInfo` has the following format:
+///
+///     {minIntegerDigits}.{minFractionDigits}-{maxFractionDigits}
+///
+/// - minIntegerDigits is the minimum number of integer digits to use. Defaults to 1.
+/// - minFractionDigits is the minimum number of digits after fraction. Defaults to 0.
+/// - maxFractionDigits is the maximum number of digits after fraction. Defaults to 3.
+///
+/// For more information on the acceptable range for each of these numbers and other
+/// details see your native internationalization library.
 @Pipe(name: "number")
 @Injectable()
 class DecimalPipe extends NumberPipe implements PipeTransform {
@@ -86,22 +77,16 @@ class DecimalPipe extends NumberPipe implements PipeTransform {
   const DecimalPipe();
 }
 
-/**
- * WARNING: this pipe uses the Internationalization API.
- * Therefore it is only reliable in Chrome and Opera browsers.
- *
- * Formats a number as local percent.
- *
- * ### Usage
- *
- *     expression | percent[:digitInfo]
- *
- * For more information about `digitInfo` see [DecimalPipe]
- *
- * ### Example
- *
- * {@example core/pipes/ts/number_pipe/number_pipe_example.ts region='PercentPipe'}
- */
+/// WARNING: this pipe uses the Internationalization API.
+/// Therefore it is only reliable in Chrome and Opera browsers.
+///
+/// Formats a number as local percent.
+///
+/// ### Usage
+///
+///     expression | percent[:digitInfo]
+///
+/// For more information about `digitInfo` see [DecimalPipe]
 @Pipe(name: "percent")
 @Injectable()
 class PercentPipe extends NumberPipe implements PipeTransform {
@@ -112,26 +97,20 @@ class PercentPipe extends NumberPipe implements PipeTransform {
   const PercentPipe();
 }
 
-/**
- * WARNING: this pipe uses the Internationalization API.
- * Therefore it is only reliable in Chrome and Opera browsers.
- *
- * Formats a number as local currency.
- *
- * ### Usage
- *
- *     expression | currency[:currencyCode[:symbolDisplay[:digitInfo]]]
- *
- * where `currencyCode` is the ISO 4217 currency code, such as "USD" for the US dollar and
- * "EUR" for the euro. `symbolDisplay` is a boolean indicating whether to use the currency
- * symbol (e.g. $) or the currency code (e.g. USD) in the output. The default for this value
- * is `false`.
- * For more information about `digitInfo` see [DecimalPipe]
- *
- * ### Example
- *
- * {@example core/pipes/ts/number_pipe/number_pipe_example.ts region='CurrencyPipe'}
- */
+/// WARNING: this pipe uses the Internationalization API.
+/// Therefore it is only reliable in Chrome and Opera browsers.
+///
+/// Formats a number as local currency.
+///
+/// ### Usage
+///
+///     expression | currency[:currencyCode[:symbolDisplay[:digitInfo]]]
+///
+/// where `currencyCode` is the ISO 4217 currency code, such as "USD" for the
+/// US dollar and "EUR" for the euro. `symbolDisplay` is a boolean indicating
+/// whether to use the currency symbol (e.g. $) or the currency code (e.g. USD)
+/// in the output. The default for this value is `false`.
+/// For more information about `digitInfo` see [DecimalPipe]
 @Pipe(name: "currency")
 @Injectable()
 class CurrencyPipe extends NumberPipe implements PipeTransform {

--- a/lib/src/common/pipes/replace_pipe.dart
+++ b/lib/src/common/pipes/replace_pipe.dart
@@ -4,31 +4,30 @@ import "package:angular2/src/facade/lang.dart"
 
 import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 
-/**
- * Creates a new String with some or all of the matches of a pattern replaced by
- * a replacement.
- *
- * The pattern to be matched is specified by the 'pattern' parameter.
- *
- * The replacement to be set is specified by the 'replacement' parameter.
- *
- * An optional 'flags' parameter can be set.
- *
- * ### Usage
- *
- *     expression | replace:pattern:replacement
- *
- * All behavior is based on the expected behavior of the JavaScript API
- * String.prototype.replace() function.
- *
- * Where the input expression is a [String] or [Number] (to be treated as a string),
- * the `pattern` is a [String] or [RegExp],
- * the 'replacement' is a [String] or [Function].
- *
- * --Note--: The 'pattern' parameter will be converted to a RegExp instance. Make sure to escape the
- * string properly if you are matching for regular expression special characters like parenthesis,
- * brackets etc.
- */
+/// Creates a new String with some or all of the matches of a pattern replaced
+/// by a replacement.
+///
+/// The pattern to be matched is specified by the 'pattern' parameter.
+///
+/// The replacement to be set is specified by the 'replacement' parameter.
+///
+/// An optional 'flags' parameter can be set.
+///
+/// ### Usage
+///
+///     expression | replace:pattern:replacement
+///
+/// All behavior is based on the expected behavior of the JavaScript API
+/// String.prototype.replace() function.
+///
+/// Where the input expression is a [String] or [Number] (to be treated as a
+/// string),
+/// the `pattern` is a [String] or [RegExp],
+/// the 'replacement' is a [String] or [Function].
+///
+/// --Note--: The 'pattern' parameter will be converted to a RegExp instance.
+/// Make sure to escape the string properly if you are matching for regular
+/// expression special characters like parenthesis, brackets etc.
 @Pipe(name: "replace")
 @Injectable()
 class ReplacePipe implements PipeTransform {

--- a/lib/src/common/pipes/slice_pipe.dart
+++ b/lib/src/common/pipes/slice_pipe.dart
@@ -5,57 +5,54 @@ import "package:angular2/src/facade/lang.dart"
 
 import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 
-/**
- * Creates a new List or String containing only a subset (slice) of the
- * elements.
- *
- * The starting index of the subset to return is specified by the `start` parameter.
- *
- * The ending index of the subset to return is specified by the optional `end` parameter.
- *
- * ### Usage
- *
- *     expression | slice:start[:end]
- *
- * All behavior is based on the expected behavior of the JavaScript API
- * Array.prototype.slice() and String.prototype.slice()
- *
- * Where the input expression is a [List] or [String], and `start` is:
- *
- * - **a positive integer**: return the item at _start_ index and all items after
- * in the list or string expression.
- * - **a negative integer**: return the item at _start_ index from the end and all items after
- * in the list or string expression.
- * - **`|start|` greater than the size of the expression**: return an empty list or string.
- * - **`|start|` negative greater than the size of the expression**: return entire list or
- * string expression.
- *
- * and where `end` is:
- *
- * - **omitted**: return all items until the end of the input
- * - **a positive integer**: return all items before _end_ index of the list or string
- * expression.
- * - **a negative integer**: return all items before _end_ index from the end of the list
- * or string expression.
- *
- * When operating on a [List], the returned list is always a copy even when all
- * the elements are being returned.
- *
- * ## List Example
- *
- * This `ngFor` example:
- *
- * {@example core/pipes/ts/slice_pipe/slice_pipe_example.ts region='SlicePipe_list'}
- *
- * produces the following:
- *
- *     <li>b</li>
- *     <li>c</li>
- *
- * ## String Examples
- *
- * {@example core/pipes/ts/slice_pipe/slice_pipe_example.ts region='SlicePipe_string'}
- */
+/// Creates a new List or String containing only a subset (slice) of the
+/// elements.
+///
+/// The starting index of the subset to return is specified by the `start`
+/// parameter.
+///
+/// The ending index of the subset to return is specified by the optional `end`
+/// parameter.
+///
+/// ### Usage
+///
+///     expression | slice:start[:end]
+///
+/// All behavior is based on the expected behavior of the JavaScript API
+/// Array.prototype.slice() and String.prototype.slice()
+///
+/// Where the input expression is a [List] or [String], and `start` is:
+///
+/// - **a positive integer**: return the item at _start_ index and all items
+/// after in the list or string expression.
+/// - **a negative integer**: return the item at _start_ index from the end and
+/// all items after in the list or string expression.
+/// - **`|start|` greater than the size of the expression**: return an empty
+/// list or string.
+/// - **`|start|` negative greater than the size of the expression**: return
+/// entire list or string expression.
+///
+/// and where `end` is:
+///
+/// - **omitted**: return all items until the end of the input
+/// - **a positive integer**: return all items before _end_ index of the list or
+/// string expression.
+/// - **a negative integer**: return all items before _end_ index from the end
+/// of the list or string expression.
+///
+/// When operating on a [List], the returned list is always a copy even when all
+/// the elements are being returned.
+///
+/// ## List Example
+///
+/// This `ngFor` example:
+///
+/// {@example core/pipes/ts/slice_pipe/slice_pipe_example.ts region='SlicePipe_list'}
+///
+/// produces the following:
+///
+///     <li>b</li>
+///     <li>c</li>
 @Pipe(name: "slice", pure: false)
 @Injectable()
 class SlicePipe implements PipeTransform {

--- a/lib/src/common/pipes/uppercase_pipe.dart
+++ b/lib/src/common/pipes/uppercase_pipe.dart
@@ -3,13 +3,7 @@ import "package:angular2/src/facade/lang.dart" show isString, isBlank;
 
 import "invalid_pipe_argument_exception.dart" show InvalidPipeArgumentException;
 
-/**
- * Implements uppercase transforms to text.
- *
- * ### Example
- *
- * {@example core/pipes/ts/lowerupper_pipe/lowerupper_pipe_example.ts region='LowerUpperPipe'}
- */
+/// Implements uppercase transforms to text.
 @Pipe(name: "uppercase")
 @Injectable()
 class UpperCasePipe implements PipeTransform {


### PR DESCRIPTION
Hi, I tried to follow the dart style guide, for library descriptions I used `//` instead of `///` because that's what I've seen in other dart-lang packages. I also tried to port the TS examples to dart as well. This PR only changes files on `lib/src/common`. Hopefully this will be helpful.

cc @kwalrath 
