### PR TITLE
Translate ng_template_outlet.ts to dart

### DIFF
--- a/lib/src/common/directives/ng_template_outlet.dart
+++ b/lib/src/common/directives/ng_template_outlet.dart
@@ -27,12 +27,10 @@ class NgTemplateOutlet implements OnChanges {
   NgTemplateOutlet(this._viewContainerRef);
 
   @Input()
-  set ngOutletContext(context) =>
-      _context = context;
+  set ngOutletContext(context) => _context = context;
 
   @Input()
-  set ngTemplateOutlet(TemplateRef templateRef) =>
-      _templateRef = templateRef;
+  set ngTemplateOutlet(TemplateRef templateRef) => _templateRef = templateRef;
 
   @override
   ngOnChanges(Map<String, SimpleChange> changes) {

--- a/lib/src/common/directives/ng_template_outlet.dart
+++ b/lib/src/common/directives/ng_template_outlet.dart
@@ -1,24 +1,47 @@
-import "package:angular2/core.dart"
-    show Directive, Input, ViewContainerRef, ViewRef, TemplateRef;
+import "package:angular2/core.dart";
+import 'package:angular2/src/core/linker/view_ref.dart';
 
 /// Creates and inserts an embedded view based on a prepared `TemplateRef`.
+/// You can attach a context object to the `EmbeddedViewRef` by setting `[ngOutletContext]`.
+/// `[ngOutletContext]` should be an object, the object's keys will be the local template variables
+/// available within the `TemplateRef`.
+///
+/// Note: using the key `$implicit` in the context object will set it's value as default.
 ///
 /// ### Syntax
-/// - `<template [ngTemplateOutlet]="templateRefExpression"></template>`
+///
+/// ```
+/// <template [ngTemplateOutlet]="templateRefExpression"
+///           [ngOutletContext]="objectExpression">
+/// </template>
+/// ```
+///
+/// @experimental
 @Directive(selector: "[ngTemplateOutlet]")
-class NgTemplateOutlet {
-  final ViewContainerRef _viewContainerRef;
-  ViewRef _insertedViewRef;
+class NgTemplateOutlet implements OnChanges {
+  EmbeddedViewRef _viewRef;
+  var _context;
+  TemplateRef _templateRef;
+  ViewContainerRef _viewContainerRef;
+
   NgTemplateOutlet(this._viewContainerRef);
+
   @Input()
-  set ngTemplateOutlet(TemplateRef templateRef) {
-    if (_insertedViewRef != null) {
-      _viewContainerRef
-          .remove(this._viewContainerRef.indexOf(this._insertedViewRef));
+  set ngOutletContext(context) =>
+      _context = context;
+
+  @Input()
+  set ngTemplateOutlet(TemplateRef templateRef) =>
+      _templateRef = templateRef;
+
+  @override
+  ngOnChanges(Map<String, SimpleChange> changes) {
+    if (_viewRef != null) {
+      _viewContainerRef.remove(_viewContainerRef.indexOf(_viewRef));
     }
-    if (templateRef != null) {
-      this._insertedViewRef =
-          this._viewContainerRef.createEmbeddedView(templateRef);
+
+    if (_templateRef != null) {
+      _viewRef = _viewContainerRef.createEmbeddedView(_templateRef, _context);
     }
   }
 }

--- a/test/common/directives/ng_template_outlet_test.dart
+++ b/test/common/directives/ng_template_outlet_test.dart
@@ -28,8 +28,7 @@ main() {
     test("should insert content specified by TemplateRef", () async {
       return inject([TestComponentBuilder, AsyncTestCompleter],
           (TestComponentBuilder tcb, AsyncTestCompleter completer) {
-        var template =
-            '<tpl-refs #refs="tplRefs">'
+        var template = '<tpl-refs #refs="tplRefs">'
             '<template>foo</template>'
             '</tpl-refs>'
             '<template [ngTemplateOutlet]="currentTplRef"></template>';
@@ -54,7 +53,8 @@ main() {
         var template =
             '<tpl-refs #refs="tplRefs"><template>foo</template></tpl-refs>'
             '<template [ngTemplateOutlet]="currentTplRef"></template>';
-        tcb.overrideTemplate(TestComponent, template)
+        tcb
+            .overrideTemplate(TestComponent, template)
             .createAsync(TestComponent)
             .then((fixture) {
           fixture.detectChanges();
@@ -73,8 +73,7 @@ main() {
     test("should swap content if TemplateRef changes", () async {
       return inject([TestComponentBuilder, AsyncTestCompleter],
           (TestComponentBuilder tcb, AsyncTestCompleter completer) {
-        var template =
-            '<tpl-refs #refs="tplRefs">'
+        var template = '<tpl-refs #refs="tplRefs">'
             '<template>foo</template>'
             '<template>bar</template>'
             '</tpl-refs>'
@@ -96,119 +95,123 @@ main() {
       });
     });
 
-    test('should display template if context is null', () async =>
-        inject(
-            [TestComponentBuilder, AsyncTestCompleter],
-            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
-          var template =
-              '<tpl-refs #refs="tplRefs">'
-              '<template>foo</template>'
-              '</tpl-refs>'
-              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="null"></template>';
-          tcb.overrideTemplate(TestComponent, template)
-              .createAsync(TestComponent)
-              .then((fixture) {
-            fixture.detectChanges();
-            expect(fixture.nativeElement, hasTextContent(''));
+    test(
+        'should display template if context is null',
+        () async => inject([TestComponentBuilder, AsyncTestCompleter],
+                (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+              var template = '<tpl-refs #refs="tplRefs">'
+                  '<template>foo</template>'
+                  '</tpl-refs>'
+                  '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="null"></template>';
+              tcb
+                  .overrideTemplate(TestComponent, template)
+                  .createAsync(TestComponent)
+                  .then((fixture) {
+                fixture.detectChanges();
+                expect(fixture.nativeElement, hasTextContent(''));
 
-            var refs = fixture.debugElement.children[0].getLocal('refs');
+                var refs = fixture.debugElement.children[0].getLocal('refs');
 
-            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
-            fixture.detectChanges();
-            expect(fixture.nativeElement, hasTextContent('foo'));
+                fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+                fixture.detectChanges();
+                expect(fixture.nativeElement, hasTextContent('foo'));
 
-            completer.done();
-          });
-        }));
+                completer.done();
+              });
+            }));
 
-    test('should reflect initial context and changes', () async =>
-        inject(
-            [TestComponentBuilder, AsyncTestCompleter],
-            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
-          var template =
-              '<tpl-refs #refs="tplRefs">'
-              '<template let-foo="foo"><span>{{foo}}</span></template>'
-              '</tpl-refs>'
-              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
-          tcb.overrideTemplate(TestComponent, template)
-              .createAsync(TestComponent)
-              .then((fixture) {
-            fixture.detectChanges();
+    test(
+        'should reflect initial context and changes',
+        () async => inject([TestComponentBuilder, AsyncTestCompleter],
+                (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+              var template = '<tpl-refs #refs="tplRefs">'
+                  '<template let-foo="foo"><span>{{foo}}</span></template>'
+                  '</tpl-refs>'
+                  '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
+              tcb
+                  .overrideTemplate(TestComponent, template)
+                  .createAsync(TestComponent)
+                  .then((fixture) {
+                fixture.detectChanges();
 
-            var refs = fixture.debugElement.children[0].getLocal('refs');
-            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+                var refs = fixture.debugElement.children[0].getLocal('refs');
+                fixture.componentInstance.currentTplRef = refs.tplRefs.first;
 
-            fixture.detectChanges();
-            expect(fixture.debugElement.nativeElement, hasTextContent('bar'));
+                fixture.detectChanges();
+                expect(
+                    fixture.debugElement.nativeElement, hasTextContent('bar'));
 
-            fixture.componentInstance.context.foo = 'alter-bar';
+                fixture.componentInstance.context.foo = 'alter-bar';
 
-            fixture.detectChanges();
-            expect(fixture.debugElement.nativeElement, hasTextContent('alter-bar'));
+                fixture.detectChanges();
+                expect(fixture.debugElement.nativeElement,
+                    hasTextContent('alter-bar'));
 
-            completer.done();
-          });
-        }));
+                completer.done();
+              });
+            }));
 
+    test(
+        'should reflect user defined \$implicit property in the context',
+        () async => inject([TestComponentBuilder, AsyncTestCompleter],
+                (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+              var template = '<tpl-refs #refs="tplRefs">'
+                  '<template let-ctx><span>{{ctx.foo}}</span></template>'
+                  '</tpl-refs>'
+                  '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
+              tcb
+                  .overrideTemplate(TestComponent, template)
+                  .createAsync(TestComponent)
+                  .then((fixture) {
+                fixture.detectChanges();
 
-    test('should reflect user defined \$implicit property in the context', () async =>
-        inject(
-            [TestComponentBuilder, AsyncTestCompleter],
-            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
-          var template =
-              '<tpl-refs #refs="tplRefs">'
-              '<template let-ctx><span>{{ctx.foo}}</span></template>'
-              '</tpl-refs>'
-              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
-          tcb.overrideTemplate(TestComponent, template)
-              .createAsync(TestComponent)
-              .then((fixture) {
-            fixture.detectChanges();
+                var refs = fixture.debugElement.children[0].getLocal('refs');
+                fixture.componentInstance.currentTplRef = refs.tplRefs.first;
 
-            var refs = fixture.debugElement.children[0].getLocal('refs');
-            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+                fixture.componentInstance.context = {
+                  '\$implicit': fixture.componentInstance.context
+                };
+                fixture.detectChanges();
+                expect(
+                    fixture.debugElement.nativeElement, hasTextContent('bar'));
 
-            fixture.componentInstance.context = {
-              '\$implicit': fixture.componentInstance.context
-            };
-            fixture.detectChanges();
-            expect(fixture.debugElement.nativeElement, hasTextContent('bar'));
+                completer.done();
+              });
+            }));
 
-            completer.done();
-          });
-        }));
+    test(
+        'should reflect context re-binding',
+        () async => inject([TestComponentBuilder, AsyncTestCompleter],
+                (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+              var template = '<tpl-refs #refs="tplRefs">'
+                  '<template let-shawshank="shawshank">'
+                  '<span>{{shawshank}}</span>'
+                  '</template>'
+                  '</tpl-refs>'
+                  '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
+              tcb
+                  .overrideTemplate(TestComponent, template)
+                  .createAsync(TestComponent)
+                  .then((fixture) {
+                fixture.detectChanges();
 
-    test('should reflect context re-binding', () async =>
-        inject(
-            [TestComponentBuilder, AsyncTestCompleter],
-            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
-          var template =
-              '<tpl-refs #refs="tplRefs">'
-              '<template let-shawshank="shawshank">'
-              '<span>{{shawshank}}</span>'
-              '</template>'
-              '</tpl-refs>'
-              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
-          tcb.overrideTemplate(TestComponent, template)
-              .createAsync(TestComponent)
-              .then((fixture) {
-            fixture.detectChanges();
+                var refs = fixture.debugElement.children[0].getLocal('refs');
+                fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+                fixture.componentInstance.context = {'shawshank': 'brooks'};
 
-            var refs = fixture.debugElement.children[0].getLocal('refs');
-            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
-            fixture.componentInstance.context = {'shawshank': 'brooks'};
+                fixture.detectChanges();
+                expect(fixture.debugElement.nativeElement,
+                    hasTextContent('brooks'));
 
-            fixture.detectChanges();
-            expect(fixture.debugElement.nativeElement, hasTextContent('brooks'));
+                fixture.componentInstance.context = {'shawshank': 'was here'};
 
-            fixture.componentInstance.context = {'shawshank': 'was here'};
+                fixture.detectChanges();
+                expect(fixture.debugElement.nativeElement,
+                    hasTextContent('was here'));
 
-            fixture.detectChanges();
-            expect(fixture.debugElement.nativeElement, hasTextContent('was here'));
-
-            completer.done();
-          });
-        }));
+                completer.done();
+              });
+            }));
   });
 }
 

--- a/test/common/directives/ng_template_outlet_test.dart
+++ b/test/common/directives/ng_template_outlet_test.dart
@@ -13,22 +13,25 @@ main() {
     test("should do nothing if templateRef is null", () async {
       return inject([TestComponentBuilder, AsyncTestCompleter],
           (TestComponentBuilder tcb, AsyncTestCompleter completer) {
-        var template = '''<template [ngTemplateOutlet]="null"></template>''';
+        var template = '<template [ngTemplateOutlet]="null"></template>';
         tcb
             .overrideTemplate(TestComponent, template)
             .createAsync(TestComponent)
             .then((fixture) {
           fixture.detectChanges();
-          expect(fixture.nativeElement, hasTextContent(""));
+          expect(fixture.nativeElement, hasTextContent(''));
           completer.done();
         });
       });
     });
+
     test("should insert content specified by TemplateRef", () async {
       return inject([TestComponentBuilder, AsyncTestCompleter],
           (TestComponentBuilder tcb, AsyncTestCompleter completer) {
         var template =
-            '<tpl-refs #refs="tplRefs"><template>foo</template></tpl-refs>'
+            '<tpl-refs #refs="tplRefs">'
+            '<template>foo</template>'
+            '</tpl-refs>'
             '<template [ngTemplateOutlet]="currentTplRef"></template>';
         tcb
             .overrideTemplate(TestComponent, template)
@@ -44,14 +47,14 @@ main() {
         });
       });
     });
+
     test("should clear content if TemplateRef becomes null", () async {
       return inject([TestComponentBuilder, AsyncTestCompleter],
           (TestComponentBuilder tcb, AsyncTestCompleter completer) {
         var template =
             '<tpl-refs #refs="tplRefs"><template>foo</template></tpl-refs>'
             '<template [ngTemplateOutlet]="currentTplRef"></template>';
-        tcb
-            .overrideTemplate(TestComponent, template)
+        tcb.overrideTemplate(TestComponent, template)
             .createAsync(TestComponent)
             .then((fixture) {
           fixture.detectChanges();
@@ -66,13 +69,16 @@ main() {
         });
       });
     });
+
     test("should swap content if TemplateRef changes", () async {
       return inject([TestComponentBuilder, AsyncTestCompleter],
           (TestComponentBuilder tcb, AsyncTestCompleter completer) {
         var template =
-            '<tpl-refs #refs="tplRefs"><template>foo</template><template>'
-            'bar</template></tpl-refs><template '
-            '[ngTemplateOutlet]="currentTplRef"></template>';
+            '<tpl-refs #refs="tplRefs">'
+            '<template>foo</template>'
+            '<template>bar</template>'
+            '</tpl-refs>'
+            '<template [ngTemplateOutlet]="currentTplRef"></template>';
         tcb
             .overrideTemplate(TestComponent, template)
             .createAsync(TestComponent)
@@ -89,6 +95,120 @@ main() {
         });
       });
     });
+
+    test('should display template if context is null', () async =>
+        inject(
+            [TestComponentBuilder, AsyncTestCompleter],
+            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+          var template =
+              '<tpl-refs #refs="tplRefs">'
+              '<template>foo</template>'
+              '</tpl-refs>'
+              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="null"></template>';
+          tcb.overrideTemplate(TestComponent, template)
+              .createAsync(TestComponent)
+              .then((fixture) {
+            fixture.detectChanges();
+            expect(fixture.nativeElement, hasTextContent(''));
+
+            var refs = fixture.debugElement.children[0].getLocal('refs');
+
+            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+            fixture.detectChanges();
+            expect(fixture.nativeElement, hasTextContent('foo'));
+
+            completer.done();
+          });
+        }));
+
+    test('should reflect initial context and changes', () async =>
+        inject(
+            [TestComponentBuilder, AsyncTestCompleter],
+            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+          var template =
+              '<tpl-refs #refs="tplRefs">'
+              '<template let-foo="foo"><span>{{foo}}</span></template>'
+              '</tpl-refs>'
+              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
+          tcb.overrideTemplate(TestComponent, template)
+              .createAsync(TestComponent)
+              .then((fixture) {
+            fixture.detectChanges();
+
+            var refs = fixture.debugElement.children[0].getLocal('refs');
+            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+
+            fixture.detectChanges();
+            expect(fixture.debugElement.nativeElement, hasTextContent('bar'));
+
+            fixture.componentInstance.context.foo = 'alter-bar';
+
+            fixture.detectChanges();
+            expect(fixture.debugElement.nativeElement, hasTextContent('alter-bar'));
+
+            completer.done();
+          });
+        }));
+
+
+    test('should reflect user defined \$implicit property in the context', () async =>
+        inject(
+            [TestComponentBuilder, AsyncTestCompleter],
+            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+          var template =
+              '<tpl-refs #refs="tplRefs">'
+              '<template let-ctx><span>{{ctx.foo}}</span></template>'
+              '</tpl-refs>'
+              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
+          tcb.overrideTemplate(TestComponent, template)
+              .createAsync(TestComponent)
+              .then((fixture) {
+            fixture.detectChanges();
+
+            var refs = fixture.debugElement.children[0].getLocal('refs');
+            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+
+            fixture.componentInstance.context = {
+              '\$implicit': fixture.componentInstance.context
+            };
+            fixture.detectChanges();
+            expect(fixture.debugElement.nativeElement, hasTextContent('bar'));
+
+            completer.done();
+          });
+        }));
+
+    test('should reflect context re-binding', () async =>
+        inject(
+            [TestComponentBuilder, AsyncTestCompleter],
+            (TestComponentBuilder tcb, AsyncTestCompleter completer) {
+          var template =
+              '<tpl-refs #refs="tplRefs">'
+              '<template let-shawshank="shawshank">'
+              '<span>{{shawshank}}</span>'
+              '</template>'
+              '</tpl-refs>'
+              '<template [ngTemplateOutlet]="currentTplRef" [ngOutletContext]="context"></template>';
+          tcb.overrideTemplate(TestComponent, template)
+              .createAsync(TestComponent)
+              .then((fixture) {
+            fixture.detectChanges();
+
+            var refs = fixture.debugElement.children[0].getLocal('refs');
+            fixture.componentInstance.currentTplRef = refs.tplRefs.first;
+            fixture.componentInstance.context = {'shawshank': 'brooks'};
+
+            fixture.detectChanges();
+            expect(fixture.debugElement.nativeElement, hasTextContent('brooks'));
+
+            fixture.componentInstance.context = {'shawshank': 'was here'};
+
+            fixture.detectChanges();
+            expect(fixture.debugElement.nativeElement, hasTextContent('was here'));
+
+            completer.done();
+          });
+        }));
   });
 }
 
@@ -104,4 +224,5 @@ class CaptureTplRefs {
     template: "")
 class TestComponent {
   TemplateRef currentTplRef;
+  Map context = {'foo': 'bar'};
 }


### PR DESCRIPTION
I converted the TS version of ng_template_outlet to dart, also converted and added the unit test related to the new context. However, all unittest are failing doubt to the change of the logic and also the next line:

``` dart
_viewRef = _viewContainerRef.createEmbeddedView(_templateRef, _context);
```

Would need to change some other files. Althought this PR contains those changes the unit-test are still failing.
