### PR TITLE
fix(transform): report invalid `entry_points`

### DIFF
--- a/lib/src/transform/common/options_reader.dart
+++ b/lib/src/transform/common/options_reader.dart
@@ -40,7 +40,7 @@ TransformerOptions parseBarbackSettings(BarbackSettings settings) {
       mirrorMode = MirrorMode.none;
       break;
   }
-  return new TransformerOptions(entryPoints,
+  var transformerOptions = new TransformerOptions(entryPoints,
       modeName: settings.mode.name,
       mirrorMode: mirrorMode,
       initReflector: initReflector,
@@ -56,6 +56,22 @@ TransformerOptions parseBarbackSettings(BarbackSettings settings) {
           _readBool(config, LAZY_TRANSFORMERS, defaultValue: false),
       translations: _readAssetId(config, TRANSLATIONS),
       formatCode: formatCode);
+
+  _checkEntryPointsExist(transformerOptions);
+  return transformerOptions;
+}
+
+/// Print an error message when an `entryPointsGlobs` value doesn't resolve to
+/// at least one file.
+void _checkEntryPointsExist(TransformerOptions transformerOptions) {
+  if (transformerOptions.entryPointGlobs != null) {
+    for (var entryPointGlob in transformerOptions.entryPointGlobs) {
+      if (entryPointGlob.listSync().isEmpty) {
+        stderr.writeln('The value "$entryPointGlob" in "entry_points" of the '
+            'Angular 2 transformer configuration does not point to any file.');
+      }
+    }
+  }
 }
 
 bool _readBool(Map config, String paramName, {bool defaultValue}) {

--- a/test/transform/common/options_reader_test.dart
+++ b/test/transform/common/options_reader_test.dart
@@ -1,0 +1,17 @@
+@TestOn('vm')
+library angular2.test.transform.common.options_reader_test;
+
+import 'dart:io';
+import 'package:test/test.dart';
+
+main() {
+  group("options_reader", () {
+    test("parseBarbackSettings reports invalid entry_points", () {
+      var processResult = Process.runSync(
+          'dart', ['./test/transform/common/print_invalid_entry_points.dart']);
+      var stdErrOutput = processResult.stderr;
+      expect(stdErrOutput, contains('"non_existing"'));
+      expect(stdErrOutput, isNot(contains('print_invalid_entry_points')));
+    });
+  });
+}

--- a/test/transform/common/print_invalid_entry_points.dart
+++ b/test/transform/common/print_invalid_entry_points.dart
@@ -1,0 +1,12 @@
+import 'package:angular2/src/transform/common/options_reader.dart';
+import 'package:barback/barback.dart';
+
+void main() {
+  var settings = new BarbackSettings({
+    'entry_points': [
+      'non_existing',
+      './test/transform/common/print_invalid_entry_points.dart'
+    ]
+  }, BarbackMode.DEBUG);
+  parseBarbackSettings(settings);
+}


### PR DESCRIPTION
print an error message to `stderr` for `entry_point` values  that don't resolve to at least one file.

fixes #38