### PR TITLE
Fix template return missing a value

### DIFF
--- a/lib/src/compiler/output/abstract_emitter.dart
+++ b/lib/src/compiler/output/abstract_emitter.dart
@@ -125,7 +125,8 @@ abstract class AbstractEmitterVisitor
   dynamic visitReturnStmt(o.ReturnStatement stmt, dynamic context) {
     EmitterVisitorContext ctx = context;
     ctx.print('''return ''');
-    stmt.value.visitExpression(this, ctx);
+
+    if (stmt.value != null) stmt.value.visitExpression(this, ctx);
     ctx.println(";");
     return null;
   }


### PR DESCRIPTION
I want to resolve #60 by enabling support for return statements without a returned expression. 😄 