### PR TITLE
Don't fail when checking `entry_points` throws

### DIFF
--- a/lib/src/transform/common/options_reader.dart
+++ b/lib/src/transform/common/options_reader.dart
@@ -64,11 +64,22 @@ TransformerOptions parseBarbackSettings(BarbackSettings settings) {
 /// Print an error message when an `entryPointsGlobs` value doesn't resolve to
 /// at least one file.
 void _checkEntryPointsExist(TransformerOptions transformerOptions) {
+  final invalidEntryPoints = [];
   if (transformerOptions.entryPointGlobs != null) {
     for (var entryPointGlob in transformerOptions.entryPointGlobs) {
-      if (entryPointGlob.listSync().isEmpty) {
-        stderr.writeln('The value "$entryPointGlob" in "entry_points" of the '
-            'Angular 2 transformer configuration does not point to any file.');
+      try {
+        if (entryPointGlob.listSync().isEmpty) {
+          invalidEntryPoints.add('$entryPointGlob');
+        }
+      } on FileSystemException catch (_) {
+        invalidEntryPoints.add('$entryPointGlob');
+      }
+    }
+    if (invalidEntryPoints.isNotEmpty) {
+      stderr.writeln('No matching file found for the following Angular2 '
+          'transformer entry_points:');
+      for (var glob in invalidEntryPoints) {
+        stderr.writeln('  - $glob');
       }
     }
   }

--- a/test/transform/common/options_reader_test.dart
+++ b/test/transform/common/options_reader_test.dart
@@ -7,10 +7,12 @@ import 'package:test/test.dart';
 main() {
   group("options_reader", () {
     test("parseBarbackSettings reports invalid entry_points", () {
-      var processResult = Process.runSync(
-          'dart', ['./test/transform/common/print_invalid_entry_points.dart']);
+      var processResult = Process.runSync('dart', [
+        './test/transform/common/print_invalid_entry_points.dart',
+      ]);
       var stdErrOutput = processResult.stderr;
-      expect(stdErrOutput, contains('"non_existing"'));
+      expect(stdErrOutput, contains('- non_existing1'));
+      expect(stdErrOutput, contains('- non_existing2/with_sub_directory'));
       expect(stdErrOutput, isNot(contains('print_invalid_entry_points')));
     });
   });

--- a/test/transform/common/print_invalid_entry_points.dart
+++ b/test/transform/common/print_invalid_entry_points.dart
@@ -4,7 +4,8 @@ import 'package:barback/barback.dart';
 void main() {
   var settings = new BarbackSettings({
     'entry_points': [
-      'non_existing',
+      'non_existing1',
+      'non_existing2/with_sub_directory',
       './test/transform/common/print_invalid_entry_points.dart'
     ]
   }, BarbackMode.DEBUG);


### PR DESCRIPTION
Work-around for #64 until a way was found to only check `entry_points` of an application package.