### PR TITLE
PipeMetadata should be pure by default.

### DIFF
--- a/lib/src/compiler/compile_metadata.dart
+++ b/lib/src/compiler/compile_metadata.dart
@@ -747,7 +747,7 @@ class CompilePipeMetadata implements CompileMetadataWithType {
       List<LifecycleHooks> lifecycleHooks}) {
     this.type = type;
     this.name = name;
-    this.pure = pure == true;
+    this.pure = pure ?? true;
     this.lifecycleHooks = lifecycleHooks ?? [];
   }
   CompileIdentifierMetadata get identifier {

--- a/test/compiler/compile_metadata_test.dart
+++ b/test/compiler/compile_metadata_test.dart
@@ -164,5 +164,10 @@ main() {
             empty.toJson());
       });
     });
+    group("PipeMetadata", () {
+      test("should be pure by default", () {
+        expect(new CompilePipeMetadata().pure, isTrue);
+      });
+    });
   });
 }


### PR DESCRIPTION
This should fix #12.