### PR TITLE
Updated analyzer dep min version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ documentation: 'https://angular.io/docs/dart/latest/api/'
 environment:
   sdk: '>=1.19.0 <2.0.0'
 dependencies:
-  analyzer: '>=0.27.0 <0.29.0'
+  analyzer: '>=0.28.0 <0.29.0'
   barback: ^0.15.2+2
   build: '>=0.3.0 <0.5.0'
   dart_style: '>=0.1.8 <0.3.0'


### PR DESCRIPTION
As of beta 22, usage of trailing commas in the source code causes the angular transformers to throw when analyzing, upgrading to 0.28.x fixes the issue.

see: https://github.com/dart-lang/angular2/issues/98