### PR TITLE
Skip tests that timeout on Travis with Firefox

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,8 +1,14 @@
 presets:
   safe_firefox:
     platforms: [firefox]
-    exclude_tags: known_ff_failure
+    exclude_tags: known_ff_failure || travis_timeout
 tags:
   needs_pub:
     skip: "Can't run tests that need pub serve. Need to figure this out."
+
+  # These need to be triaged and fixed – but we don't want to block running
+  # on Travis
   known_ff_failure:
+  # Due to a hard-coded timeout in pkg/test LoadSuite
+  # https://github.com/dart-lang/test/issues/390
+  travis_timeout:

--- a/test/common/forms/model_test.dart
+++ b/test/common/forms/model_test.dart
@@ -1,4 +1,5 @@
 @TestOn('browser')
+@Tags(const ['travis_timeout'])
 library angular2.test.common.forms.model_spec;
 
 import 'dart:async';

--- a/test/common/forms/validators_test.dart
+++ b/test/common/forms/validators_test.dart
@@ -1,4 +1,5 @@
 @TestOn('browser')
+@Tags(const ['travis_timeout'])
 library angular2.test.common.forms.validators_spec;
 
 import "dart:async";

--- a/test/compiler/directive_normalizer_test.dart
+++ b/test/compiler/directive_normalizer_test.dart
@@ -1,4 +1,4 @@
-@TestOn('browser && !js')
+@TestOn('browser')
 library angular2.test.compiler.directive_normalizer_test;
 
 import 'package:angular2/testing_internal.dart';

--- a/test/compiler/template_parser_test.dart
+++ b/test/compiler/template_parser_test.dart
@@ -1,4 +1,5 @@
 @TestOn('browser')
+@Tags(const ['travis_timeout'])
 library angular2.test.compiler.template_parser_test;
 
 import "package:angular2/testing_internal.dart";

--- a/test/compiler/template_preparser_test.dart
+++ b/test/compiler/template_preparser_test.dart
@@ -1,4 +1,5 @@
 @TestOn('browser')
+@Tags(const ['travis_timeout'])
 library angular2.test.compiler.template_preparser_test;
 
 import "package:angular2/testing_internal.dart";

--- a/test/core/di/reflective_injector_test.dart
+++ b/test/core/di/reflective_injector_test.dart
@@ -1,4 +1,5 @@
 @TestOn('browser')
+@Tags(const ['travis_timeout'])
 library angular2.test.core.di.reflective_injector_test;
 
 import "package:angular2/src/facade/lang.dart" show stringify;

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -3,6 +3,11 @@
 # Fast fail the script on failures.
 set -e
 
+if [ -z "$TEST_PLATFORM" ]; then
+  echo "TEST_PLATFORM must be set"
+  exit 1
+fi
+
 # Run a trivial travis-only test to see if the browser platform is even working
 pub run test -p $TEST_PLATFORM tool/travis_sniff_test.dart
 


### PR DESCRIPTION
See https://github.com/dart-lang/test/issues/470

Also let folks know that tool/travis.sh requires TEST_PLATFORM set