### PR TITLE
Re-enable dev SDK + content-shell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ before_script:
 script: ./tool/travis.sh
 matrix:
   allow_failures:
-  # Need compile timeout in pgk/test to be longer than 5 minutes
+  # Waiting for
+  # https://github.com/dart-lang/test/commit/685a7c3b
+  # to land in a released build – seems to fix it
   - env: TEST_PLATFORM=firefox
-  # content shell issues with latest dev - https://github.com/dart-lang/sdk/issues/27418
-  - env: TEST_PLATFORM=content-shell
-    dart: dev

--- a/test/compiler/directive_normalizer_test.dart
+++ b/test/compiler/directive_normalizer_test.dart
@@ -1,4 +1,4 @@
-@TestOn('browser && !js')
+@TestOn('browser')
 library angular2.test.compiler.directive_normalizer_test;
 
 import 'package:angular2/testing_internal.dart';

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -3,6 +3,11 @@
 # Fast fail the script on failures.
 set -e
 
+if [ -z "$TEST_PLATFORM" ]; then
+  echo "TEST_PLATFORM must be set"
+  exit 1
+fi
+
 # Run a trivial travis-only test to see if the browser platform is even working
 pub run test -p $TEST_PLATFORM tool/travis_sniff_test.dart
 


### PR DESCRIPTION
Allow one more test to run with dart2js
Add a sanity check in travis.sh to make sure env variables are set