### PR TITLE
Another cleanup pass on grammar

### DIFF
--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -5,49 +5,46 @@
 * What is Banana formally known as?
 
 ```dart
-Whitespace = " " | "\t" | "\n" | "\r" ;
+WhiteSpace = " " | "\t" | "\n" | "\r" ;
+Letter = [a-zA-Z] ;
+Digit = [0-9] ;
+Fragment = (Digit | Letter)+ ;
+StartFragment = Letter, [Fragment] ;
 
-// Upper case letters are lowercased
-AsciiLetter = "a" | ... | "Z" ;
+/// A TagName identifies HTML elements and components.
+///
+/// Uppercase letters are converted to lowercase by the parser.
+TagName = StartFragment, [ "-", Fragment ]* ;
 
-TagFragment = AsciiLetter+ ;
+// Does it make sense to distinguish between Tags and Components?
+Node = VoidTag | OpenTag, [Node]*, CloseTag | Comment ;
+OpenTag = "<", TagName, Whitespace+, [Attribute, Whitespace+]*, ">" ;
+VoidTag = "<", TagName, Whitespace+, [Attribute, Whitespace+]*, "/>" ;
+CloseTag = "</", TagName, Whitespace*, ">" ;
+Comment = "<!--", [Text]+ , "-->"
 
-TagName = TagFragment, [ "-" TagFragment]* ;
 
-AttributeName = // TODO - there are lots of things that are allowed attribute names that maybe we don't want to... ;
+/// An AttributeName with added restrictions from HTML.
+///
+/// In order to make the grammar of directives less ambiguous,
+/// There is an added restriction of the characters '*', '[', ']'
+/// '(', ')', and '#'.
+AttributeName = [^"`'//=\t\n\r \(\)\[\]\*#]+
+AttributeValue = '"', Text+, '"'
 
-RawText = (Text | Interpolation)* ;
+Attribute = Normal | Structural | Input | Event | Banana | Binding ;
+Normal = AttributeName | AttributeName, "=", AttributeValue ;
+Structural = "*", AttributeName, "=", (QuotedDartExpression | StructuralExpression);
+Input = "[", AttributeName, "]=", QuotedDartExpression ;
+Event = "(", AttributeName, ")=", QuotedDartExpression ;
+Banana = "[(", AttributeName, ")]=", QuotedDartExpression ;
+Binding = "#", AttributeName ;
+
+Text = (RawText | Interpolation)* ;
+Interpolation = "{{", QuotedDartExpression , "}}" ;
 
 Text = ... everything but /, <, {{ ;
 
-Interpolation = "{{", DartExpression , "}}" ;
 
-DartExpression = // TODO ;
-
-Tag = TagSelfClosing | TagOpen, [RawText | Tag+ | Comment], TagClose ;
-
-TagOpen = "<", TagName, Whitespace+, [Attribute, Whitespace]*, ">" ;
-
-TagSelfClosing = "<", TagName, Whitespace+, [Attribute, [Whitespace]+]* , "/>" ;
-
-TagClose = "</", TagName, Whitespace*, ">" ;
-
-Comment = "<!--", [Text]+ , "-->"
-
-Attribute = Normal | Structural | Input | Output | Banana | Binding ;
-
-Normal = AttributeName | AttributeName, "=", AttributeValue ;
-
-// Not sure about this one.
-AttributeValue = '"', RawText , '"' ;
-
-Structural = "*", AttributeName, "=", '"', (DartExpression | NgForExpression), '"' ;
-
-Input = "[", AttributeName, "]", "=", '"', DartExpression ;
-
-Output= "(", AttributeName, ")", "=", '"', DartExpression ;
-
-Banana = "[(", AttributeName, ")", "]", "=", '"', DartExpression ;
-
-Binding = "#", AttriubteName ;
+QuotedDartExpression = '"', 'Dart without double quotes?', '"';
 ```

--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -50,8 +50,4 @@ Output= "(", AttributeName, ")", "=", '"', DartExpression ;
 Banana = "[(", AttributeName, ")", "]", "=", '"', DartExpression ;
 
 Binding = "#", AttriubteName ;
-
-DartExpression = // TODO ;
-
-NgForExpression = // TODO ;
 ```

--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -1,3 +1,9 @@
+#TODO:
+* Resolve ambiguities regarding what characters are allowed in different kinds of text blocks (possibly splitting them up).
+* Specify what features of HTML are not supported.
+* Including missing grammar elements.
+* What is Banana formally known as?
+
 ```dart
 Whitespace = " " | "\t" | "\n" | "\r" ;
 
@@ -8,27 +14,28 @@ TagFragment = AsciiLetter+ ;
 
 TagName = TagFragment, [ "-" TagFragment]* ;
 
-AttributeName = // TODO ;
+AttributeName = // TODO - there are lots of things that are allowed attribute names that maybe we don't want to... ;
 
-RawText = // TODO ;
+RawText = (Text | Interpolation)* ;
+
+Text = ... everything but /, <, {{ ;
 
 Interpolation = "{{", DartExpression , "}}" ;
 
 DartExpression = // TODO ;
 
-// Tags
-Tag = TagSelfClosing | TagOpen, [RawText | Tag+ ], TagClose ;
+Tag = TagSelfClosing | TagOpen, [RawText | Tag+ | Comment], TagClose ;
 
 TagOpen = "<", TagName, Whitespace+, [Attribute, Whitespace]*, ">" ;
 
-TagSelfClosing = "<", TagName, Whitespace+, [Attribute, Whitespace]*, "/>" ;
+TagSelfClosing = "<", TagName, Whitespace+, [Attribute, [Whitespace]+]* , "/>" ;
 
 TagClose = "</", TagName, Whitespace*, ">" ;
 
-// Attributes
+Comment = "<!--", [Text]+ , "-->"
+
 Attribute = Normal | Structural | Input | Output | Banana | Binding ;
 
-// TODO: are attributes without values supported?
 Normal = AttributeName | AttributeName, "=", AttributeValue ;
 
 // Not sure about this one.
@@ -40,7 +47,9 @@ Input = "[", AttributeName, "]", "=", '"', DartExpression ;
 
 Output= "(", AttributeName, ")", "=", '"', DartExpression ;
 
-Combined = "[(", AttributeName, ")", "]", "=", '"', DartExpression ;
+Banana = "[(", AttributeName, ")", "]", "=", '"', DartExpression ;
+
+Binding = "#", AttriubteName ;
 
 DartExpression = // TODO ;
 

--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -1,0 +1,48 @@
+```dart
+Whitespace = " " | "\t" | "\n" | "\r" ;
+
+// Upper case letters are lowercased
+AsciiLetter = "a" | ... | "Z" ;
+
+TagFragment = AsciiLetter+ ;
+
+TagName = TagFragment, [ "-" TagFragment]* ;
+
+AttributeName = // TODO ;
+
+RawText = // TODO ;
+
+Interpolation = "{{", DartExpression , "}}" ;
+
+DartExpression = // TODO ;
+
+// Tags
+Tag = TagSelfClosing | TagOpen, [RawText | Tag+ ], TagClose ;
+
+TagOpen = "<", TagName, Whitespace+, [Attribute, Whitespace]*, ">" ;
+
+TagSelfClosing = "<", TagName, Whitespace+, [Attribute, Whitespace]*, "/>" ;
+
+TagClose = "</", TagName, Whitespace*, ">" ;
+
+// Attributes
+Attribute = Normal | Structural | Input | Output | Banana | Binding ;
+
+// TODO: are attributes without values supported?
+Normal = AttributeName | AttributeName, "=", AttributeValue ;
+
+// Not sure about this one.
+AttributeValue = '"', RawText , '"' ;
+
+Structural = "*", AttributeName, "=", '"', (DartExpression | NgForExpression), '"' ;
+
+Input = "[", AttributeName, "]", "=", '"', DartExpression ;
+
+Output= "(", AttributeName, ")", "=", '"', DartExpression ;
+
+Combined = "[(", AttributeName, ")", "]", "=", '"', DartExpression ;
+
+DartExpression = // TODO ;
+
+NgForExpression = // TODO ;
+```

--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -1,26 +1,26 @@
 #Template Grammar.
 
 ```
-WhiteSpace      = " " | "\t" | "\n" | "\r" ;
-Letter          = [a-zA-Z] ;
-Digit           = [0-9] ;
-Fragment        = (Digit | Letter)+ ;
-TagName         = Letter, [Fragment], [ "-", Fragment ]* ;
-Node            = VoidTag | OpenTag, [Node]*, CloseTag | Comment ;
-OpenTag         = "<", TagName, WhiteSpace+, [Attribute, WhiteSpace+]*, ">" ;
-VoidTag         = "<", TagName, WhiteSpace+, [Attribute, WhiteSpace+]*, "/>" ;
-CloseTag        = "</", TagName, WhiteSpace*, ">" ;
-Comment         = "<!--", [RawText]+ , "-->"
-AttributeName   = [^"`'//=\t\n\r \(\)\[\]\*#]+ ;
-AttributeValue  = '"', Text+, '"' ;
-Attribute       = Normal | Structural | Input | Event | Banana | Binding ;
-Normal          = AttributeName | AttributeName, "=", AttributeValue ;
+WhiteSpace      = " " | "\t" | "\n" | "\r";
+Letter          = [a-zA-Z];
+Digit           = [0-9];
+Fragment        = (Digit | Letter)+;
+TagName         = Letter, [Fragment], [ "-", Fragment ]*;
+Node            = VoidTag | OpenTag, [Node]*, CloseTag | Comment;
+OpenTag         = "<", TagName, WhiteSpace+, [Attribute, WhiteSpace+]*, ">";
+VoidTag         = "<", TagName, WhiteSpace+, [Attribute, WhiteSpace+]*, "/>";
+CloseTag        = "</", TagName, WhiteSpace*, ">";
+Comment         = "<!--", [RawText]+ , "-->";
+AttributeName   = [^"`'//=\t\n\r \(\)\[\]\*#]+;
+AttributeValue  = '"', Text+, '"';
+Attribute       = Normal | Structural | Input | Event | Banana | Binding;
+Normal          = AttributeName | AttributeName, "=", AttributeValue;
 Structural      = "*", AttributeName, "=", (QuotedDartExpression | StructuralExpression);
-Input           = "[", AttributeName, "]=", QuotedDartExpression ;
-Event           = "(", AttributeName, ")=", QuotedDartExpression ;
-Banana          = "[(", AttributeName, ")]=", QuotedDartExpression ;
-Binding         = "#", AttributeName ;
+Input           = "[", AttributeName, "]=", QuotedDartExpression;
+Event           = "(", AttributeName, ")=", QuotedDartExpression;
+Banana          = "[(", AttributeName, ")]=", QuotedDartExpression;
+Binding         = "#", AttributeName;
 Text            = (RawText | Interpolation)* ;
-Interpolation   = "{{", QuotedDartExpression , "}}" ;
+Interpolation   = "{{", QuotedDartExpression , "}}";
 QuotedDartExpression = '"', 'Dart without double quotes?', '"';
 ```

--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -1,47 +1,26 @@
-#TODO:
-* Resolve ambiguities regarding what characters are allowed in different kinds of text blocks (possibly splitting them up).
-* Specify what features of HTML are not supported.
-* Including missing grammar elements.
-* What is Banana formally known as?
+#Template Grammar.
 
-```dart
-WhiteSpace = " " | "\t" | "\n" | "\r" ;
-Letter = [a-zA-Z] ;
-Digit = [0-9] ;
-Fragment = (Digit | Letter)+ ;
-
-/// A TagName identifies HTML elements and components.
-///
-/// Uppercase letters are converted to lowercase by the parser.
-/// Tags must begin with a Letter.
-TagName = Letter, [Fragment], [ "-", Fragment ]* ;
-
-
-Node = VoidTag | OpenTag, [Node]*, CloseTag | Comment ;
-OpenTag = "<", TagName, Whitespace+, [Attribute, Whitespace+]*, ">" ;
-VoidTag = "<", TagName, Whitespace+, [Attribute, Whitespace+]*, "/>" ;
-CloseTag = "</", TagName, Whitespace*, ">" ;
-Comment = "<!--", [RawText]+ , "-->"
-
-
-/// An AttributeName with added restrictions from HTML.
-///
-/// In order to make the grammar of directives less ambiguous,
-/// There is an added restriction of the characters '*', '[', ']'
-/// '(', ')', and '#'.
-AttributeName = [^"`'//=\t\n\r \(\)\[\]\*#]+ ;
-AttributeValue = '"', Text+, '"' ;
-
-Attribute = Normal | Structural | Input | Event | Banana | Binding ;
-Normal = AttributeName | AttributeName, "=", AttributeValue ;
-Structural = "*", AttributeName, "=", (QuotedDartExpression | StructuralExpression);
-Input = "[", AttributeName, "]=", QuotedDartExpression ;
-Event = "(", AttributeName, ")=", QuotedDartExpression ;
-Banana = "[(", AttributeName, ")]=", QuotedDartExpression ;
-Binding = "#", AttributeName ;
-
-Text = (RawText | Interpolation)* ;
-Interpolation = "{{", QuotedDartExpression , "}}" ;
-
+```
+WhiteSpace      = " " | "\t" | "\n" | "\r" ;
+Letter          = [a-zA-Z] ;
+Digit           = [0-9] ;
+Fragment        = (Digit | Letter)+ ;
+TagName         = Letter, [Fragment], [ "-", Fragment ]* ;
+Node            = VoidTag | OpenTag, [Node]*, CloseTag | Comment ;
+OpenTag         = "<", TagName, WhiteSpace+, [Attribute, WhiteSpace+]*, ">" ;
+VoidTag         = "<", TagName, WhiteSpace+, [Attribute, WhiteSpace+]*, "/>" ;
+CloseTag        = "</", TagName, WhiteSpace*, ">" ;
+Comment         = "<!--", [RawText]+ , "-->"
+AttributeName   = [^"`'//=\t\n\r \(\)\[\]\*#]+ ;
+AttributeValue  = '"', Text+, '"' ;
+Attribute       = Normal | Structural | Input | Event | Banana | Binding ;
+Normal          = AttributeName | AttributeName, "=", AttributeValue ;
+Structural      = "*", AttributeName, "=", (QuotedDartExpression | StructuralExpression);
+Input           = "[", AttributeName, "]=", QuotedDartExpression ;
+Event           = "(", AttributeName, ")=", QuotedDartExpression ;
+Banana          = "[(", AttributeName, ")]=", QuotedDartExpression ;
+Binding         = "#", AttributeName ;
+Text            = (RawText | Interpolation)* ;
+Interpolation   = "{{", QuotedDartExpression , "}}" ;
 QuotedDartExpression = '"', 'Dart without double quotes?', '"';
 ```

--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -43,8 +43,5 @@ Binding = "#", AttributeName ;
 Text = (RawText | Interpolation)* ;
 Interpolation = "{{", QuotedDartExpression , "}}" ;
 
-Text = ... everything but /, <, {{ ;
-
-
 QuotedDartExpression = '"', 'Dart without double quotes?', '"';
 ```

--- a/lib/src/modules/compiler/template_parser/GRAMMAR.md
+++ b/lib/src/modules/compiler/template_parser/GRAMMAR.md
@@ -9,19 +9,19 @@ WhiteSpace = " " | "\t" | "\n" | "\r" ;
 Letter = [a-zA-Z] ;
 Digit = [0-9] ;
 Fragment = (Digit | Letter)+ ;
-StartFragment = Letter, [Fragment] ;
 
 /// A TagName identifies HTML elements and components.
 ///
 /// Uppercase letters are converted to lowercase by the parser.
-TagName = StartFragment, [ "-", Fragment ]* ;
+/// Tags must begin with a Letter.
+TagName = Letter, [Fragment], [ "-", Fragment ]* ;
 
-// Does it make sense to distinguish between Tags and Components?
+
 Node = VoidTag | OpenTag, [Node]*, CloseTag | Comment ;
 OpenTag = "<", TagName, Whitespace+, [Attribute, Whitespace+]*, ">" ;
 VoidTag = "<", TagName, Whitespace+, [Attribute, Whitespace+]*, "/>" ;
 CloseTag = "</", TagName, Whitespace*, ">" ;
-Comment = "<!--", [Text]+ , "-->"
+Comment = "<!--", [RawText]+ , "-->"
 
 
 /// An AttributeName with added restrictions from HTML.
@@ -29,8 +29,8 @@ Comment = "<!--", [Text]+ , "-->"
 /// In order to make the grammar of directives less ambiguous,
 /// There is an added restriction of the characters '*', '[', ']'
 /// '(', ')', and '#'.
-AttributeName = [^"`'//=\t\n\r \(\)\[\]\*#]+
-AttributeValue = '"', Text+, '"'
+AttributeName = [^"`'//=\t\n\r \(\)\[\]\*#]+ ;
+AttributeValue = '"', Text+, '"' ;
 
 Attribute = Normal | Structural | Input | Event | Banana | Binding ;
 Normal = AttributeName | AttributeName, "=", AttributeValue ;


### PR DESCRIPTION
still todo: define what is allowed in text nodes, dart expressions, and the whole ngFor thing