### PR TITLE
Added dart analyzer 

### DIFF
--- a/lib/src/modules/compiler/template_parser/lib/src/utils.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/utils.dart
@@ -1,4 +1,45 @@
 import 'package:charcode/charcode.dart';
+import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/src/dart/scanner/scanner.dart';
+import 'package:analyzer/src/dart/scanner/reader.dart';
+// import 'package:analyzer/src/dart/ast/ast.dart';
+import 'package:analyzer/src/generated/parser.dart';
+import 'package:analyzer/src/string_source.dart';
+
+/// Attempts to parse a String into an unresolved AST expression.
+Expression parseAngularExpression(String contents, String name,
+    {bool suppressErrors: false, bool parseFunctionBodies: true}) {
+  var source = new StringSource(contents, name);
+  var reader = new CharSequenceReader(contents);
+  var errorCollector = new _ErrorCollector();
+  var scanner = new Scanner(source, reader, errorCollector);
+  var token = scanner.tokenize();
+  var parser = new Parser(source, errorCollector)
+    ..parseFunctionBodies = parseFunctionBodies;
+  var unit = parser.parseExpression(token);
+
+  if (errorCollector.hasErrors && !suppressErrors) throw errorCollector.group;
+
+  return unit;
+}
+
+/// Taken from package:analyzer/analyzer.dart.
+/// A simple error listener that collects errors into an [AnalyzerErrorGroup].
+class _ErrorCollector extends AnalysisErrorListener {
+  final _errors = <AnalysisError>[];
+
+  _ErrorCollector();
+
+  /// The group of errors collected.
+  AnalyzerErrorGroup get group =>
+      new AnalyzerErrorGroup.fromAnalysisErrors(_errors);
+
+  /// Whether any errors where collected.
+  bool get hasErrors => _errors.isNotEmpty;
+
+  @override
+  void onError(AnalysisError error) => _errors.add(error);
+}
 
 /// A `[` character.
 const int $openProperty = $open_bracket;

--- a/lib/src/modules/compiler/template_parser/pubspec.yaml
+++ b/lib/src/modules/compiler/template_parser/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   collection: "^1.0.0"
   meta: "^1.0.4"
   string_scanner: "^1.0.0"
+  analyzer:
   quiver:
 
 dev_dependencies:

--- a/lib/src/modules/compiler/template_parser/test/ast/expression_parsing_test.dart
+++ b/lib/src/modules/compiler/template_parser/test/ast/expression_parsing_test.dart
@@ -1,0 +1,16 @@
+import 'package:test/test.dart';
+import 'package:angular2_template_parser/src/utils.dart';
+import 'package:analyzer/analyzer.dart';
+
+void main() {
+  group('The Dart analyzer', () {
+    test('can be used to parse expressions', () {
+      expect(parseAngularExpression('1 + 1', 'template'),
+          new isInstanceOf<Expression>());
+    });
+
+    test('will yield errors on bad inputs', () {
+      expect(() => parseAngularExpression('1 + ', 'template'), throws);
+    });
+  });
+}


### PR DESCRIPTION
imported analyzer for expression parsing and implemented simple method `parseAngularExpression(..)` using `Parse.parseExpression(...)`.

Still todo:  add additional field to Angular ast nodes containing a parsedExpression, as well as an error class for parse failures.  (wanted to wait until the previous PRs were in).