### PR TITLE
Add parsing of Event, Property, Interpolate nodes into Dart AST

### DIFF
--- a/lib/src/modules/compiler/template_parser/lib/src/ast.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast.dart
@@ -3,9 +3,11 @@ library angular2_template_parser.src.ast;
 import 'package:collection/collection.dart';
 import 'package:source_span/source_span.dart';
 import 'package:quiver/core.dart';
+import 'package:analyzer/analyzer.dart';
 
 import 'lexer.dart';
 import 'schema.dart';
+import 'utils.dart';
 
 part 'ast/attribute.dart';
 part 'ast/binding.dart';

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/event.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/event.dart
@@ -8,6 +8,11 @@ class NgEvent extends NgAstNode with NgAstSourceTokenMixin {
   /// Listener of the event (an expression).
   final String value;
 
+  /// A parsed Dart expression.
+  ///
+  /// should be set with parseAngularExpression(...)
+  Expression expression;
+
   NgEvent(this.name, this.value) : super._(const []);
 
   NgEvent.fromTokens(
@@ -24,14 +29,8 @@ class NgEvent extends NgAstNode with NgAstSourceTokenMixin {
 
   /// Creates an Event action from a banana desugar.  Has new
   /// names and values but links to original source.
-  NgEvent.fromBanana(
-    NgToken before,
-    NgToken start,
-    NgToken name,
-    NgToken equals,
-    NgToken value,
-    NgToken end
-  )
+  NgEvent.fromBanana(NgToken before, NgToken start, NgToken name,
+      NgToken equals, NgToken value, NgToken end)
       : this.name = '${name.text}Change',
         this.value = '${value.text} = \$event',
         super._([before, start, name, equals, value, end]);

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/interpolation.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/interpolation.dart
@@ -5,6 +5,11 @@ class NgInterpolation extends NgAstNode with NgAstSourceTokenMixin {
   /// Expression value.
   final String value;
 
+  /// A parsed Dart expression.
+  ///
+  /// should be set with parseAngularExpression(...)
+  Expression expression;
+
   /// Create a new [NgInterpolation] node.
   NgInterpolation(this.value) : super._(const []);
 

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/property.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/property.dart
@@ -8,6 +8,11 @@ class NgProperty extends NgAstNode with NgAstSourceTokenMixin {
   /// Value of the property (an expression).
   final String value;
 
+  /// A parsed Dart expression.
+  ///
+  /// should be set with parseAngularExpression(...)
+  Expression expression;
+
   NgProperty(this.name, this.value) : super._(const []);
 
   NgProperty.fromTokens(

--- a/lib/src/modules/compiler/template_parser/lib/src/errors.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/errors.dart
@@ -1,12 +1,15 @@
 library angular2_template_parser.src.compiler_error;
 
 import 'package:source_span/source_span.dart';
+import 'package:analyzer/analyzer.dart';
 
 import 'ast.dart';
 import 'lexer.dart';
 
 part 'errors/extra_structural_directive.dart';
 part 'errors/illegal_tag_name.dart';
+part 'errors/invalid_dart_expression.dart';
+part 'errors/banana_limited_identifier.dart';
 
 /// Represents errors with [SourceSpan]s found while parsing.
 abstract class SourceError implements Error {

--- a/lib/src/modules/compiler/template_parser/lib/src/errors/banana_limited_identifier.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/errors/banana_limited_identifier.dart
@@ -1,0 +1,22 @@
+part of angular2_template_parser.src.compiler_error;
+
+/// When a banana (in a box) binding contains more than a single
+/// identifier.
+///
+/// TODO: find a better name for this guy.
+class BananaLimitedIdentifierError extends SourceError {
+  /// The parsed [NgToken] representing the element name.
+  final NgToken elementToken;
+
+  factory BananaLimitedIdentifierError(NgToken elementToken) {
+    return new BananaLimitedIdentifierError._(
+        elementToken, elementToken.source);
+  }
+
+  BananaLimitedIdentifierError._(this.elementToken, SourceSpan context)
+      : super._(context);
+
+  @override
+  String toString() => toFriendlyMessage(
+      header: 'Banana (in a box) should only contain an identifier');
+}

--- a/lib/src/modules/compiler/template_parser/lib/src/errors/invalid_dart_expression.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/errors/invalid_dart_expression.dart
@@ -1,0 +1,25 @@
+part of angular2_template_parser.src.compiler_error;
+
+/// When an [NgTokenType.interpolation], [NgTokenType.eventValue],
+/// [NgTokenType.propertyValue] contains a Dart expression which is rejected
+/// by the analyzer.
+class InvalidDartExpressionError extends SourceError {
+  /// The parsed [NgToken] representing the element name.
+  final NgToken elementToken;
+
+  /// The original error from the analyzer.
+  final AnalyzerErrorGroup analysisError;
+
+  factory InvalidDartExpressionError(
+      NgToken elementToken, AnalyzerErrorGroup analysisError) {
+    return new InvalidDartExpressionError._(
+        elementToken, analysisError, elementToken.source);
+  }
+
+  InvalidDartExpressionError._(
+      this.elementToken, this.analysisError, SourceSpan context)
+      : super._(context);
+
+  @override
+  String toString() => toFriendlyMessage(header: analysisError.message);
+}

--- a/lib/src/modules/compiler/template_parser/test/error_test.dart
+++ b/lib/src/modules/compiler/template_parser/test/error_test.dart
@@ -32,4 +32,49 @@ void main() {
         '      </template>\n'
         '    </template>');
   });
+
+  test('should fail when interpolation nodes have invalid dart expressions',
+      () {
+    expect(
+        getParseError('<div> 1 + 1 = {{1 + }}</div>'),
+        'line 1, column 17: Error in interpolation node: Expected an identifier\n'
+        '\n'
+        '<div> 1 + 1 = {{1 + }}</div>\n'
+        '                ^^^^\n'
+        '\n'
+        '');
+  });
+
+  test('should fail when there is more than an identifier in a banana', () {
+    expect(getParseErrors('<div [(prop)]="1 +"></div>'), [
+      'line 1, column 16: Error in bananan (in a box): Expected an identifier\n'
+          '\n'
+          '<div [(prop)]="1 +"></div>\n'
+          '               ^^^\n'
+          '\n'
+          ''
+    ]);
+  });
+
+  test('should fail when an event node contains an invalid expression', () {
+    expect(
+        getParseError('<div (click)="1 +"></div>'),
+        'line 1, column 15: Error in event node: Expected an identifier\n'
+        '\n'
+        '<div (click)="1 +"></div>\n'
+        '              ^^^\n'
+        '\n'
+        '');
+  });
+
+  test('should fail when a property node contains an invalid expression', () {
+    expect(
+        getParseError('<div [prop]="1 + "></div>'),
+        'line 1, column 14: Error in property node: Expected an identifier\n'
+        '\n'
+        '<div [prop]="1 + "></div>\n'
+        '             ^^^^\n'
+        '\n'
+        '');
+  });
 }


### PR DESCRIPTION
Added an `expression` field onto the Event, Property, and Interpolate nodes.

Added parsing of the value field into an expression in the parser, with specific errors for invalid expressions.

Restricts the RHS of the banana in a box to only be an identifier, so that we can be sure the transformation into an event and property will work.


fixme on these bugs still needs work, for the analyzer errors I am just passing them through basically.