### PR TITLE
Basic visitor implementation and Unparser

### DIFF
--- a/lib/src/modules/compiler/template_parser/lib/src/ast.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast.dart
@@ -79,9 +79,7 @@ abstract class NgAstNode {
   NgAstNode map(NgAstNode mapping(NgAstNode node)) => mapping(this);
 
 
-  /// Accepts a [Visitor] and calls the correct
-  /// method on it.
-  ///
+  /// Accepts a [Visitor] and calls the correct method on it.
   void visit(Visitor visitor);
 }
 

--- a/lib/src/modules/compiler/template_parser/lib/src/ast.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/analyzer.dart';
 
 import 'lexer.dart';
 import 'schema.dart';
+import 'visitor.dart';
 
 part 'ast/attribute.dart';
 part 'ast/binding.dart';
@@ -76,6 +77,12 @@ abstract class NgAstNode {
   /// attributes to a new NgAstNode.
   ///
   NgAstNode map(NgAstNode mapping(NgAstNode node)) => mapping(this);
+
+
+  /// Accepts a [Visitor] and calls the correct
+  /// method on it.
+  ///
+  void visit(Visitor visitor);
 }
 
 /// An [NgAstNode] that is expected to be recognized in a schema.

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/attribute.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/attribute.dart
@@ -43,4 +43,7 @@ class NgAttribute extends NgAstNode with NgAstSourceTokenMixin {
 
   @override
   String toString() => '$NgAttribute $name="$value"';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitAttribute(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/binding.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/binding.dart
@@ -31,4 +31,7 @@ class NgBinding extends NgAstNode with NgAstSourceTokenMixin {
 
   @override
   String toString() => '$NgBinding #$name';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitBinding(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/comment.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/comment.dart
@@ -45,4 +45,7 @@ class NgComment extends NgAstNode with NgAstSourceTokenMixin {
 
   @override
   String toString() => '$NgComment <!--$value-->';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitComment(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/element.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/element.dart
@@ -66,4 +66,7 @@ class NgElement extends NgAstNode
 
   @override
   String toString() => '$NgElement <$name> [${childNodes.join(', ')}]';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitElement(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/event.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/event.dart
@@ -48,4 +48,7 @@ class NgEvent extends NgAstNode with NgAstSourceTokenMixin {
 
   @override
   String toString() => '$NgEvent ($name)="$value"';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitEvent(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/interpolation.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/interpolation.dart
@@ -29,4 +29,7 @@ class NgInterpolation extends NgAstNode with NgAstSourceTokenMixin {
 
   @override
   String toString() => '$NgInterpolation $value';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitInterpolation(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/property.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/property.dart
@@ -40,4 +40,7 @@ class NgProperty extends NgAstNode with NgAstSourceTokenMixin {
 
   @override
   String toString() => '$NgProperty [$name]="$value"';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitProperty(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/ast/text.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/ast/text.dart
@@ -25,4 +25,7 @@ class NgText extends NgAstNode with NgAstSourceTokenMixin {
 
   @override
   String toString() => '$NgText $value';
+
+  @override
+  void visit(Visitor visitor) => visitor.visitText(this);
 }

--- a/lib/src/modules/compiler/template_parser/lib/src/parser.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/parser.dart
@@ -2,6 +2,7 @@ import 'ast.dart';
 import 'lexer.dart';
 import 'errors.dart';
 import 'utils.dart';
+import 'visitor.dart';
 
 import 'package:source_span/src/span.dart';
 import 'package:analyzer/analyzer.dart';
@@ -48,6 +49,10 @@ class _Fragment implements NgAstNode {
     return new _Fragment()
       ..childNodes.addAll(childNodes.map((node) => node.map(mapping)));
   }
+
+  @override
+  void visit(Visitor visitor) => childNodes
+    .forEach((node) => node.visit(visitor));
 }
 
 typedef void ErrorCallback(Error error);

--- a/lib/src/modules/compiler/template_parser/lib/src/parser.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/parser.dart
@@ -51,8 +51,8 @@ class _Fragment implements NgAstNode {
   }
 
   @override
-  void visit(Visitor visitor) => childNodes
-    .forEach((node) => node.visit(visitor));
+  void visit(Visitor visitor) =>
+      childNodes.forEach((node) => node.visit(visitor));
 }
 
 typedef void ErrorCallback(Error error);

--- a/lib/src/modules/compiler/template_parser/lib/src/visitor.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/visitor.dart
@@ -4,10 +4,10 @@ import 'ast.dart';
 
 part 'visitor/unparser.dart';
 
-/// [Visitor] interface is provided to an [NgAstNode] node via
-/// the `visit(Visitor visitor)` method, and can be used to do
-/// all the things that visitors do.
+/// Allows visiting of an [NgAstNode].
 ///
+/// [Visitor] interface is provided to an [NgAstNode] node via
+/// the `visit(Visitor visitor)` method.
 abstract class Visitor {
   const Visitor();
 

--- a/lib/src/modules/compiler/template_parser/lib/src/visitor.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/visitor.dart
@@ -1,0 +1,29 @@
+library angular2_template_parser.src.visitor;
+
+import 'ast.dart';
+
+part 'visitor/unparser.dart';
+
+/// [Visitor] interface is provided to an [NgAstNode] node via
+/// the `visit(Visitor visitor)` method, and can be used to do
+/// all the things that visitors do.
+///
+abstract class Visitor {
+  const Visitor();
+
+  void visitAttribute(NgAttribute node);
+
+  void visitBinding(NgBinding node);
+
+  void visitComment(NgComment node);
+
+  void visitElement(NgElement node);
+
+  void visitInterpolation(NgInterpolation node);
+
+  void visitProperty(NgProperty node);
+
+  void visitEvent(NgEvent node);
+
+  void visitText(NgText node);
+}

--- a/lib/src/modules/compiler/template_parser/lib/src/visitor/unparser.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/visitor/unparser.dart
@@ -1,13 +1,17 @@
 part of angular2_template_parser.src.visitor;
 
-/// this is an example [Visitor] implementation used to
-/// produce a basic printout of the original source using an efficient
-/// [StringBuffer] and lite formatting.  This does not use the original text,
-/// so it can be used to produce new html files from
-/// modified trees.
+/// This is a [Visitor] for producing a source template from an [NgAstNode].
 ///
-/// Currently does not handle desugaring from a banana in a box
-/// or structural directives.
+/// This is a stateful visitor, so at most one Unparser can be used per unparse.
+/// Currently does not handle desugaring from a banana in a box or structural
+/// directives.
+///
+/// example_use:
+///     NgAstNode node;
+///     Unparser unparser = new Unparser();
+///     node.visit(unparser);
+///     // The AST as source template.
+///     print(unparser);
 class Unparser implements Visitor {
   static bool _onElementBody(NgAstNode node) =>
       node is! NgComment &&

--- a/lib/src/modules/compiler/template_parser/lib/src/visitor/unparser.dart
+++ b/lib/src/modules/compiler/template_parser/lib/src/visitor/unparser.dart
@@ -1,0 +1,90 @@
+part of angular2_template_parser.src.visitor;
+
+/// this is an example [Visitor] implementation used to
+/// produce a basic printout of the original source using an efficient
+/// [StringBuffer] and lite formatting.  This does not use the original text,
+/// so it can be used to produce new html files from
+/// modified trees.
+///
+/// Currently does not handle desugaring from a banana in a box
+/// or structural directives.
+class Unparser implements Visitor {
+  static bool _onElementBody(NgAstNode node) =>
+      node is! NgComment &&
+      node is! NgElement &&
+      node is! NgText &&
+      node is! NgBinding;
+
+  final StringBuffer _buffer = new StringBuffer();
+  int _level = 0;
+
+  Unparser();
+
+  void _indent() {
+    _level++;
+  }
+
+  void _unindent() {
+    _level--;
+  }
+
+  String get _indentation => '  ' * _level;
+
+  @override
+  void visitAttribute(NgAttribute node) {
+    _buffer.write(' ${node.name}');
+    if (node.value != null) {
+      _buffer.write('="${node.value}"');
+    }
+  }
+
+  @override
+  void visitBinding(NgBinding node) {
+    _buffer.write(' #${node.name}');
+  }
+
+  @override
+  void visitComment(NgComment node) {
+    _buffer.writeln('$_indentation ${node.source.text}');
+  }
+
+  @override
+  void visitText(NgText node) {
+    _buffer.writeln('$_indentation${node.source.text}');
+  }
+
+  @override
+  void visitElement(NgElement node) {
+    _buffer.write('$_indentation<${node.name}');
+
+    for (final node in node.childNodes.takeWhile(_onElementBody)) {
+      node.visit(this);
+    }
+    _buffer.writeln('>');
+    _indent();
+
+    for (final node in node.childNodes.skipWhile(_onElementBody)) {
+      node.visit(this);
+    }
+    _unindent();
+    _buffer.writeln('$_indentation</${node.name}>');
+  }
+
+  @override
+  void visitEvent(NgEvent node) {
+    _buffer.write(' (${node.name})=${node.value}');
+  }
+
+  @override
+  void visitInterpolation(NgInterpolation node) {
+    _buffer.writeln('$_indentation{{${node.value}}}');
+  }
+
+  @override
+  void visitProperty(NgProperty node) {
+    _buffer.write(' [${node.name}]="${node.value}"');
+  }
+
+  @override
+  String toString() => _buffer.toString();
+}

--- a/lib/src/modules/compiler/template_parser/test/visitor/unparser_test.dart
+++ b/lib/src/modules/compiler/template_parser/test/visitor/unparser_test.dart
@@ -1,0 +1,49 @@
+import 'package:angular2_template_parser/template_parser.dart';
+import 'package:test/test.dart';
+import 'package:angular2_template_parser/src/visitor.dart';
+
+void main() {
+  NgAstNode parse(String text) =>
+      const NgTemplateParser().parse(text, onError: (_) => null).first;
+
+  test('produces a desugared template', () {
+    var ast = parse('<panel><div *ngIf="isTrue">Foo Bar</div><button '
+      'class="fancy" disabled>Hello</button></panel>');
+    var printer = new Unparser();
+    ast.visit(printer);
+    expect(printer.toString(), equals(
+      '<panel>\n'
+      '  <template [ngIf]="isTrue">\n'
+      '    <div>\n'
+      '      Foo Bar\n'
+      '    </div>\n'
+      '  </template>\n'
+      '  <button class="fancy" disabled>\n'
+      '    Hello\n'
+      '  </button>\n'
+      '</panel>\n'
+    ));
+  });
+
+  test('can be used on renamed templates', () {
+    var ast = parse('<div class="baz"><ng-app [prop]="foo">Test</ng-app></div>');
+    NgAstNode renamer(NgAstNode node) {
+      if (node is NgElement) {
+        return new NgElement.unknown('${node.name}-test',
+          childNodes: node.childNodes
+            .map((x) => x.map(renamer)).toList());
+      }
+      return node;
+    }
+    var newAst = ast.map(renamer);
+    var printer = new Unparser();
+    newAst.visit(printer);
+    expect(printer.toString(), equals(
+      '<div-test class="baz">\n'
+      '  <ng-app-test [prop]="foo">\n'
+      '    Test\n'
+      '  </ng-app-test>\n'
+      '</div-test>\n'
+    ));
+  });
+}


### PR DESCRIPTION
Added a basic visitor implementation, and an unparser based on it.

Does not currently 'de-sugar' banana and structural directives, but it can be extended too (though the AST might need a few modifications as well).