### PR TITLE
Async pipe can now handle StreamController.stream's properly

### DIFF
--- a/lib/src/common/pipes/async_pipe.dart
+++ b/lib/src/common/pipes/async_pipe.dart
@@ -69,7 +69,8 @@ class AsyncPipe implements OnDestroy {
       this._latestReturnedValue = this._latestValue;
       return this._latestValue;
     }
-    if (!identical(obj, this._obj)) {
+    print('${_maybeStreamIdentical(obj, this._obj)}');
+    if(!_maybeStreamIdentical(obj, this._obj)) {
       this._dispose();
       return this.transform(obj);
     }
@@ -112,6 +113,14 @@ class AsyncPipe implements OnDestroy {
     if (identical(async, this._obj)) {
       this._latestValue = value;
       this._ref.markForCheck();
+    }
+  }
+
+  static bool _maybeStreamIdentical(dynamic a, dynamic b) {
+    if(a is Stream && b is Stream) {
+      return identical(a, b) || a == b;
+    } else {
+      return identical(a, b);
     }
   }
 }

--- a/lib/src/common/pipes/async_pipe.dart
+++ b/lib/src/common/pipes/async_pipe.dart
@@ -69,7 +69,8 @@ class AsyncPipe implements OnDestroy {
       this._latestReturnedValue = this._latestValue;
       return this._latestValue;
     }
-    print('${_maybeStreamIdentical(obj, this._obj)}');
+    // StreamController.stream getter always returns new Stream instance,
+    // operator== check is also needed. See https://github.com/dart-lang/angular2/issues/260
     if(!_maybeStreamIdentical(obj, this._obj)) {
       this._dispose();
       return this.transform(obj);
@@ -116,11 +117,10 @@ class AsyncPipe implements OnDestroy {
     }
   }
 
-  static bool _maybeStreamIdentical(dynamic a, dynamic b) {
-    if(a is Stream && b is Stream) {
-      return identical(a, b) || a == b;
-    } else {
-      return identical(a, b);
+  static bool _maybeStreamIdentical(a, b) {
+    if (!identical(a, b)) {
+      return a is Stream && b is Stream && a == b;
     }
+    return true;
   }
 }

--- a/test/common/pipes/async_pipe_test.dart
+++ b/test/common/pipes/async_pipe_test.dart
@@ -67,6 +67,18 @@ void main() {
           });
         });
       });
+      test('should not dispose of existing subscription when Streams are equal', () async {
+        return inject([AsyncTestCompleter], (AsyncTestCompleter completer) {
+          // See https://github.com/dart-lang/angular2/issues/260
+          StreamController _ctrl = new StreamController.broadcast();
+          expect(pipe.transform(_ctrl.stream), isNull);
+          _ctrl.add(message);
+          Timer.run(() {
+            expect(pipe.transform(_ctrl.stream), isNotNull);
+            completer.done();
+          });
+        });
+      });
       test('should request a change detection check upon receiving a new value',
           () async {
         return inject([AsyncTestCompleter], (AsyncTestCompleter completer) {


### PR DESCRIPTION
fixes dart-lang/angular2#260

I imagine a couple of test cases could be added to this fix.

