### PR TITLE
Add doc links to cheat sheet

### DIFF
--- a/doc/cheatsheet/bootstrapping.md
+++ b/doc/cheatsheet/bootstrapping.md
@@ -9,3 +9,6 @@ syntax:
 `bootstrap​(AppComponent, [MyService, provide(...)]);`|`provide`
 description:
 Bootstraps the app, using `AppComponent` as the root component.
+
+See: [Architecture Overview](/angular/guide/architecture),
+[bootstrap function](/angular/api/angular2.platform.browser/bootstrap)

--- a/doc/cheatsheet/built-in-directives.md
+++ b/doc/cheatsheet/built-in-directives.md
@@ -10,11 +10,19 @@ syntax:
 description:
 Removes or recreates a portion of the DOM tree based on the `showSection` expression.
 
+See: [Template Syntax](/angular/guide/template-syntax),
+[NgIf class](/angular/api/angular2.common/NgIf-class)
+
+
 @cheatsheetItem
 syntax:
 `<li *ngFor="let item of list">`|`*ngFor`
 description:
 Turns the li element and its contents into a template, and uses that to instantiate a view for each item in list.
+
+See: [Template Syntax](/angular/guide/template-syntax),
+[NgFor class](/angular/api/angular2.common/NgFor-class)
+
 
 @cheatsheetItem
 syntax:
@@ -26,8 +34,18 @@ syntax:
 description:
 Conditionally swaps the contents of the div by selecting one of the embedded templates based on the current value of conditionExpression.
 
+See: [Template Syntax](/angular/guide/template-syntax),
+[NgSwitch class](/angular/api/angular2.common/NgSwitch-class),
+[NgSwitchWhen class](/angular/api/angular2.common/NgSwitchWhen-class),
+[NgSwitchDefault class](/angular/api/angular2.common/NgSwitchDefault-class)
+
 @cheatsheetItem
 syntax:
 `<div [ngClass]="{active: isActive, disabled: isDisabled}">`|`[ngClass]`
 description:
 Binds the presence of CSS classes on the element to the truthiness of the associated map values. The right-hand expression should return {class-name: true/false} map.
+
+See: [Template Syntax](/angular/guide/template-syntax),
+[NgClass class](/angular/api/angular2.common/NgClass-class)
+
+<!-- Why isn't NgStyle in here or in the TS cheat sheet? -->

--- a/doc/cheatsheet/class-decorators.md
+++ b/doc/cheatsheet/class-decorators.md
@@ -11,12 +11,20 @@ class MyComponent() {}`|`@Component(...)`
 description:
 Declares that a class is a component and provides metadata about the component.
 
+See: [Architecture Overview](/angular/guide/architecture),
+[Component class](/angular/api/angular2.core/Component-class)
+
+
 @cheatsheetItem
 syntax:
 `@Directive(...)
 class MyDirective() {}`|`@Directive(...)`
 description:
 Declares that a class is a directive and provides metadata about the directive.
+
+See: [Architecture Overview](/angular/guide/architecture),
+[Directive class](/angular/api/angular2.core/Directive-class)
+
 
 @cheatsheetItem
 syntax:
@@ -25,9 +33,16 @@ class MyPipe() {}`|`@Pipe(...)`
 description:
 Declares that a class is a pipe and provides metadata about the pipe.
 
+See: [Pipes](/angular/guide/pipes),
+[Pipe class](/angular/api/angular2.core/Pipe-class)
+
+
 @cheatsheetItem
 syntax:
 `@Injectable()
 class MyService() {}`|`@Injectable()`
 description:
 Declares that a class has dependencies that should be injected into the constructor when the dependency injector is creating an instance of this class.
+
+See: [Dependency Injection](/angular/guide/dependency-injection),
+[Injectable class](/angular/api/angular2.core/Injectable-class)

--- a/doc/cheatsheet/component-configuration.md
+++ b/doc/cheatsheet/component-configuration.md
@@ -11,6 +11,8 @@ syntax:
 description:
 List of dependency injection providers scoped to this component's view.
 
+See: [viewProviders property](/angular/api/angular2.core/Component/viewProviders)
+
 
 @cheatsheetItem
 syntax:
@@ -18,6 +20,8 @@ syntax:
 templateUrl: 'my-component.html'`|`template:`|`templateUrl:`
 description:
 Inline template or external template URL of the component's view.
+
+See: [Architecture Overview](/angular/guide/architecture)
 
 
 @cheatsheetItem
@@ -27,6 +31,8 @@ styleUrls: ['my-component.css']`|`styles:`|`styleUrls:`
 description:
 List of inline CSS styles or external stylesheet URLs for styling the component’s view.
 
+See: [Component Styles](/angular/guide/component-styles)
+
 
 @cheatsheetItem
 syntax:
@@ -34,9 +40,13 @@ syntax:
 description:
 List of directives used in the component's template.
 
+See: [Architecture Overview](/angular/guide/architecture)
+
 
 @cheatsheetItem
 syntax:
 `pipes: [MyPipe, OtherPipe]`|`pipes:`
 description:
 List of pipes used in the component's template.
+
+See: [Pipes](/angular/guide/pipes)

--- a/doc/cheatsheet/dependency-injection.md
+++ b/doc/cheatsheet/dependency-injection.md
@@ -6,20 +6,35 @@ Dependency injection configuration
 
 @cheatsheetItem
 syntax:
-`provide(MyService, useClass: MyMockService)`|`provide`|`useClass`
+`const Provider(MyService, useClass: MyMockService)`|`Provider`|`useClass`
 description:
 Sets or overrides the provider for `MyService` to the `MyMockService` class.
 
+See:
+[Dependency Injection](/angular/guide/dependency-injection),
+[provide function](/angular/api/angular2.core/provide),
+[Provider class](/angular/api/angular2.core/Provider-class)
+
 
 @cheatsheetItem
 syntax:
-`provide(MyService, useFactory: myFactory)`|`provide`|`useFactory`
+`const Provider(MyService, useFactory: myFactory)`|`Provider`|`useFactory`
 description:
 Sets or overrides the provider for `MyService` to the `myFactory` factory function.
 
+See:
+[Dependency Injection](/angular/guide/dependency-injection),
+[provide function](/angular/api/angular2.core/provide),
+[Provider class](/angular/api/angular2.core/Provider-class)
+
 
 @cheatsheetItem
 syntax:
-`provide(MyValue, useValue: 41)`|`provide`|`useValue`
+`const Provider(MyValue, useValue: 41)`|`Provider`|`useValue`
 description:
 Sets or overrides the provider for `MyValue` to the value `41`.
+
+See:
+[Dependency Injection](/angular/guide/dependency-injection),
+[provide function](/angular/api/angular2.core/provide),
+[Provider class](/angular/api/angular2.core/Provider-class)

--- a/doc/cheatsheet/directive-and-component-decorators.md
+++ b/doc/cheatsheet/directive-and-component-decorators.md
@@ -11,12 +11,18 @@ description:
 Declares an input property that you can update via property binding (example:
 `<my-cmp [myProperty]="someExpression">`).
 
+See: [Template Syntax](/angular/guide/template-syntax),
+[Input class](/angular/api/angular2.core/Input-class)
+
 
 @cheatsheetItem
 syntax:
 `@Output() myEvent = new EventEmitter();`|`@Output()`
 description:
 Declares an output property that fires events that you can subscribe to with an event binding (example: `<my-cmp (myEvent)="doSomething()">`).
+
+See: [Template Syntax](/angular/guide/template-syntax),
+[Output class](/angular/api/angular2.core/Output-class)
 
 
 @cheatsheetItem
@@ -25,12 +31,17 @@ syntax:
 description:
 Binds a host element property (here, the CSS class `valid`) to a directive/component property (`isValid`).
 
+See: [HostBinding class](/angular/api/angular2.core/HostBinding-class)
+
 
 @cheatsheetItem
 syntax:
 `@HostListener('click', ['$event']) onClick(e) {...}`|`@HostListener('click', ['$event'])`
 description:
 Subscribes to a host element event (`click`) with a directive/component method (`onClick`), optionally passing an argument (`$event`).
+
+See: [Attribute Directives](/angular/guide/attribute-directives),
+[HostListener class](/angular/api/angular2.core/HostListener-class)
 
 
 @cheatsheetItem
@@ -39,12 +50,16 @@ syntax:
 description:
 Binds the first result of the component content query (`myPredicate`) to a property (`myChildComponent`) of the class.
 
+See: [ContentChild class](/angular/api/angular2.core/ContentChild-class)
+
 
 @cheatsheetItem
 syntax:
 `@ContentChildren(myPredicate) myChildComponents;`|`@ContentChildren(myPredicate)`
 description:
 Binds the results of the component content query (`myPredicate`) to a property (`myChildComponents`) of the class.
+
+See: [ContentChildren class](/angular/api/angular2.core/ContentChildren-class)
 
 
 @cheatsheetItem
@@ -53,9 +68,13 @@ syntax:
 description:
 Binds the first result of the component view query (`myPredicate`) to a property (`myChildComponent`) of the class. Not available for directives.
 
+See: [ViewChild class](/angular/api/angular2.core/ViewChild-class)
+
 
 @cheatsheetItem
 syntax:
 `@ViewChildren(myPredicate) myChildComponents;`|`@ViewChildren(myPredicate)`
 description:
 Binds the results of the component view query (`myPredicate`) to a property (`myChildComponents`) of the class. Not available for directives.
+
+See: [ViewChildren class](/angular/api/angular2.core/ViewChildren-class)

--- a/doc/cheatsheet/directive-configuration.md
+++ b/doc/cheatsheet/directive-configuration.md
@@ -13,8 +13,17 @@ Specifies a CSS selector that identifies this directive within a template. Suppo
 
 Does not support parent-child relationship selectors.
 
+See: [Structural Directives](/angular/guide/structural-directives),
+[selector property](/angular/api/angular2.core/Directive/selector)
+
+
 @cheatsheetItem
 syntax:
 `providers: [MyService, provide(...)]`|`providers:`
 description:
 List of dependency injection providers for this directive and its children.
+
+See:
+[Attribute Directives](/angular/guide/attribute-directives),
+[Structural Directives](/angular/guide/structural-directives),
+[providers property](/angular/api/angular2.core/Directive/providers)

--- a/doc/cheatsheet/forms.md
+++ b/doc/cheatsheet/forms.md
@@ -9,3 +9,6 @@ syntax:
 `<input [(ngModel)]="userName">`|`[(ngModel)]`
 description:
 Provides two-way data-binding, parsing, and validation for form controls.
+
+See: [Forms](/angular/guide/forms),
+[NgModel class](/angular/api/angular2.common/NgModel-class)

--- a/doc/cheatsheet/lifecycle-hooks.md
+++ b/doc/cheatsheet/lifecycle-hooks.md
@@ -10,12 +10,17 @@ syntax:
 description:
 Called before any other lifecycle hook. Use it to inject dependencies, but avoid any serious work here.
 
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks)
+
 
 @cheatsheetItem
 syntax:
 `ngOnChanges(changeRecord) { ... }`|`ngOnChanges(changeRecord)`
 description:
 Called after every change to input properties and before processing content or child views.
+
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[OnChanges class](/angular/api/angular2.core/OnChanges-class)
 
 
 @cheatsheetItem
@@ -24,12 +29,18 @@ syntax:
 description:
 Called after the constructor, initializing input properties, and the first call to `ngOnChanges`.
 
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[OnInit class](/angular/api/angular2.core/OnInit-class)
+
 
 @cheatsheetItem
 syntax:
 `ngDoCheck() { ... }`|`ngDoCheck()`
 description:
 Called every time that the input properties of a component or a directive are checked. Use it to extend change detection by performing a custom check.
+
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[DoCheck class](/angular/api/angular2.core/DoCheck-class)
 
 
 @cheatsheetItem
@@ -38,12 +49,18 @@ syntax:
 description:
 Called after ngOnInit when the component's or directive's content has been initialized.
 
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[AfterContentInit class](/angular/api/angular2.core/AfterContentInit-class)
+
 
 @cheatsheetItem
 syntax:
 `ngAfterContentChecked() { ... }`|`ngAfterContentChecked()`
 description:
 Called after every check of the component's or directive's content.
+
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[AfterContentChecked class](/angular/api/angular2.core/AfterContentChecked-class)
 
 
 @cheatsheetItem
@@ -52,6 +69,9 @@ syntax:
 description:
 Called after `ngAfterContentInit` when the component's view has been initialized. Applies to components only.
 
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[AfterViewInit class](/angular/api/angular2.core/AfterViewInit-class)
+
 
 @cheatsheetItem
 syntax:
@@ -59,9 +79,15 @@ syntax:
 description:
 Called after every check of the component's view. Applies to components only.
 
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[AfterViewChecked class](/angular/api/angular2.core/AfterViewChecked-class)
+
 
 @cheatsheetItem
 syntax:
 `ngOnDestroy() { ... }`|`ngOnDestroy()`
 description:
 Called once, before the instance is destroyed.
+
+See: [Lifecycle Hooks](/angular/guide/lifecycle-hooks),
+[OnDestroy class](/angular/api/angular2.core/OnDestroy-class)

--- a/doc/cheatsheet/routing.md
+++ b/doc/cheatsheet/routing.md
@@ -16,12 +16,21 @@ syntax:
 description:
 Configures routes for the decorated component. Supports static, parameterized, and wildcard routes.
 
+See:
+[Tutorial: Routing](/angular/tutorial/toh-pt5),
+[RouteConfig class](/angular/api/angular2.router/RouteConfig-class),
+[Route class](/angular/api/angular2.router/Route-class)
+
 
 @cheatsheetItem
 syntax:
 `<router-outlet></router-outlet>`|`router-outlet`
 description:
 Marks the location to load the component of the active route.
+
+See:
+[Tutorial: Routing](/angular/tutorial/toh-pt5),
+[RouterOutlet class](/angular/api/angular2.router/RouterOutlet-class)
 
 
 @cheatsheetItem
@@ -30,11 +39,17 @@ syntax:
 description:
 Creates a link to a different view based on a route instruction consisting of a route name and optional parameters. To navigate to a root route, use the `/` prefix; for a child route, use the `./`prefix.
 
+See:
+[Tutorial: Routing](/angular/tutorial/toh-pt5),
+[RouterLink class](/angular/api/angular2.router/RouterLink-class)
+
+
 @cheatsheetItem
 syntax:
 `@CanActivate(() => ...)class MyComponent() {}`|`@CanActivate`
 description:
 A component decorator defining a function that the router should call first to determine if it should activate this component. Should return a boolean or a future.
+<!-- TODO: link to good resource. -->
 
 
 @cheatsheetItem
@@ -44,6 +59,8 @@ syntax:
 description:
 After navigating to a component, the router calls the component's `routerOnActivate` method (if defined).
 
+See: [OnActivate class](/angular/api/angular2.router/OnActivate-class)
+
 
 @cheatsheetItem
 syntax:
@@ -51,6 +68,8 @@ syntax:
     prevInstruction) { ... }`|`routerCanReuse`
 description:
 The router calls a component's `routerCanReuse` method (if defined) to determine whether to reuse the instance or destroy it and create a new instance. Should return a boolean or a future.
+
+See: [CanReuse class](/angular/api/angular2.router/CanReuse-class)
 
 
 @cheatsheetItem
@@ -60,6 +79,8 @@ syntax:
 description:
 The router calls the component's `routerOnReuse` method (if defined) when it reuses a component instance.
 
+See: [OnReuse class](/angular/api/angular2.router/OnReuse-class)
+
 
 @cheatsheetItem
 syntax:
@@ -68,6 +89,8 @@ syntax:
 description:
 The router calls the `routerCanDeactivate` methods (if defined) of every component that would be removed after a navigation. The navigation proceeds if and only if all such methods return true or a future that completes successfully.
 
+See: [CanDeactivate class](/angular/api/angular2.router/CanDeactivate-class)
+
 
 @cheatsheetItem
 syntax:
@@ -75,3 +98,5 @@ syntax:
     prevInstruction) { ... }`|`routerOnDeactivate`
 description:
 Called before the directive is removed as the result of a route change. May return a future that pauses removing the directive until the future completes.
+
+See: [OnDeactivate class](/angular/api/angular2.router/OnDeactivate-class)

--- a/doc/cheatsheet/template-syntax.md
+++ b/doc/cheatsheet/template-syntax.md
@@ -9,11 +9,17 @@ syntax:
 description:
 Binds property `value` to the result of expression `firstName`.
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<div [attr.role]="myAriaRole">`|`[attr.role]`
 description:
 Binds attribute `role` to the result of expression `myAriaRole`.
+
+See: [Template Syntax](/angular/guide/template-syntax)
+
 
 @cheatsheetItem
 syntax:
@@ -21,17 +27,26 @@ syntax:
 description:
 Binds the presence of the CSS class `extra-sparkle` on the element to the truthiness of the expression `isDelightful`.
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<div [style.width.px]="mySize">`|`[style.width.px]`
 description:
 Binds style property `width` to the result of expression `mySize` in pixels. Units are optional.
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<button (click)="readRainbow($event)">`|`(click)`
 description:
 Calls method `readRainbow` when a click event is triggered on this button element (or its children) and passes in the event object.
+
+See: [Template Syntax](/angular/guide/template-syntax)
+
 
 @cheatsheetItem
 syntax:
@@ -40,17 +55,26 @@ description:
 Binds a property to an interpolated string, for example, "Hello Seabiscuit". Equivalent to:
 `<div [title]="'Hello' + ponyName">`
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<p>Hello {{ponyName}}</p>`|`{{ponyName}}`
 description:
 Binds text content to an interpolated string, for example, "Hello Seabiscuit".
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<my-cmp [(title)]="name">`|`[(title)]`
 description:
 Sets up two-way data binding. Equivalent to: `<my-cmp [title]="name" (titleChange)="name=$event">`
+
+See: [Template Syntax](/angular/guide/template-syntax)
+
 
 @cheatsheetItem
 syntax:
@@ -60,6 +84,9 @@ syntax:
 description:
 Creates a local variable `movieplayer` that provides access to the `video` element instance in data-binding and event-binding expressions in the current template.
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<p *myUnless="myExpression">...</p>`|`*myUnless`
@@ -67,14 +94,22 @@ description:
 The `*` symbol turns the current element into an embedded template. Equivalent to:
 `<template [myUnless]="myExpression"><p>...</p></template>`
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<p>Card No.: {{cardNumber | myCardNumberFormatter}}</p>`|`{{cardNumber | myCardNumberFormatter}}`
 description:
 Transforms the current value of expression `cardNumber` via the pipe called `myCardNumberFormatter`.
 
+See: [Template Syntax](/angular/guide/template-syntax)
+
+
 @cheatsheetItem
 syntax:
 `<p>Employer: {{employer?.companyName}}</p>`|`{{employer?.companyName}}`
 description:
 The safe navigation operator (`?`) means that the `employer` field is optional and if `undefined`, the rest of the expression should be ignored.
+
+See: [Template Syntax](/angular/guide/template-syntax)


### PR DESCRIPTION
PR here for better visibility, but I can make the changes to the internal repo.

Staged version:
https://kw-webdev-dartlang-1.firebaseapp.com/angular/cheatsheet

Compare to:
https://webdev.dartlang.org/angular/cheatsheet

What do you think of the format and the actual links? I started out with the links at the end of the main description (not a separate paragraph), but although it saved space, it seemed a bit ugly and unclear.

Fixes https://github.com/dart-lang/site-webdev/issues/210.

cc @mehaase, @chalin 