### PR TITLE
API docs: replace @example with @source + inlined code

### DIFF
--- a/lib/platform/browser.dart
+++ b/lib/platform/browser.dart
@@ -105,9 +105,13 @@ PlatformRef browserPlatform() {
 ///
 /// ### Examples
 ///
-/// {@example docs/quickstart/web/main.dart}
+/// ```dart
+/// // {@source "docs/quickstart/web/main.dart"}
+/// ```
 ///
-/// {@example docs/toh-6/web/main.dart}
+/// ```dart
+/// // {@source "docs/toh-6/web/main.dart"}
+/// ```
 ///
 /// For details concerning these examples see the
 /// [Quickstart](docs/quickstart.html) and

--- a/lib/platform/browser.dart
+++ b/lib/platform/browser.dart
@@ -107,10 +107,31 @@ PlatformRef browserPlatform() {
 ///
 /// ```dart
 /// // {@source "docs/quickstart/web/main.dart"}
+/// import 'package:angular2/platform/browser.dart';
+/// 
+/// import 'package:angular_quickstart/app_component.dart';
+/// 
+/// void main() {
+///   bootstrap(AppComponent);
+/// }
+/// 
 /// ```
 ///
 /// ```dart
 /// // {@source "docs/toh-6/web/main.dart"}
+/// import 'package:angular2/core.dart';
+/// import 'package:angular2/platform/browser.dart';
+/// import 'package:angular_tour_of_heroes/app_component.dart';
+/// import 'package:angular_tour_of_heroes/in_memory_data_service.dart';
+/// import 'package:http/http.dart';
+/// 
+/// void main() {
+///   bootstrap(AppComponent,
+///     [provide(Client, useClass: InMemoryDataService)]
+///     // Using a real back end? Import browser_client.dart and change the above to
+///     // [provide(Client, useFactory: () => new BrowserClient(), deps: [])]
+///   );
+/// }
 /// ```
 ///
 /// For details concerning these examples see the

--- a/lib/src/common/directives/ng_class.dart
+++ b/lib/src/common/directives/ng_class.dart
@@ -26,10 +26,23 @@ import 'package:angular2/src/core/change_detection/differs/default_keyvalue_diff
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgClass-1"} -->
+/// <div [ngClass]="setClasses()">This div is saveable and special</div>
 /// ```
 ///
 /// ```dart
 /// // {@source "docs/template-syntax/lib/app_component.dart" region="setClasses"}
+///   Map<String, bool> setClasses() {
+///     final classes = {
+///       'saveable': canSave, // true
+///       'modified': !isUnchanged, // false
+///       'special': isSpecial // true
+///     };
+///     // compensate for DevMode (sigh)
+///     if (JSON.encode(_previousClasses) == JSON.encode(classes))
+///       return _previousClasses;
+///     _previousClasses = classes;
+///     return classes;
+///   }
 /// ```
 ///
 /// Try the [live example][ex].

--- a/lib/src/common/directives/ng_class.dart
+++ b/lib/src/common/directives/ng_class.dart
@@ -24,9 +24,13 @@ import 'package:angular2/src/core/change_detection/differs/default_keyvalue_diff
 ///
 /// ### Examples
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgClass-1}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgClass-1"} -->
+/// ```
 ///
-/// {@example docs/template-syntax/lib/app_component.dart region=setClasses}
+/// ```dart
+/// // {@source "docs/template-syntax/lib/app_component.dart" region="setClasses"}
+/// ```
 ///
 /// Try the [live example][ex].
 /// See the [Template Syntax section on `ngClass`][guide] for more details.

--- a/lib/src/common/directives/ng_for.dart
+++ b/lib/src/common/directives/ng_for.dart
@@ -63,18 +63,24 @@ import "../../core/change_detection/differs/default_iterable_differ.dart"
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgFor-1"} -->
+/// <div *ngFor="let hero of heroes">{{hero.fullName}}</div>
 /// ```
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgFor-3"} -->
+/// <div *ngFor="let hero of heroes; let i=index">{{i + 1}} - {{hero.fullName}}</div>
 /// ```
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="Template-3"} -->
+/// <hero-detail template="ngFor let hero of heroes; trackBy:trackByHeroes" [hero]="hero"></hero-detail>
 /// ```
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="Template-4"} -->
+/// <template ngFor let-hero [ngForOf]="heroes" [ngForTrackBy]="trackByHeroes">
+///   <hero-detail [hero]="hero"></hero-detail>
+/// </template>
 /// ```
 ///
 /// See the [Template Syntax section on `ngFor`][guide] for details.

--- a/lib/src/common/directives/ng_for.dart
+++ b/lib/src/common/directives/ng_for.dart
@@ -61,13 +61,21 @@ import "../../core/change_detection/differs/default_iterable_differ.dart"
 ///
 /// ### Examples
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgFor-1}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgFor-1"} -->
+/// ```
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgFor-3}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgFor-3"} -->
+/// ```
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=Template-3}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="Template-3"} -->
+/// ```
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=Template-4}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="Template-4"} -->
+/// ```
 ///
 /// See the [Template Syntax section on `ngFor`][guide] for details.
 ///

--- a/lib/src/common/directives/ng_if.dart
+++ b/lib/src/common/directives/ng_if.dart
@@ -9,9 +9,13 @@ import 'package:angular2/core.dart'
 ///
 /// ### Examples
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgIf-1}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgIf-1"} -->
+/// ```
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=Template-2}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="Template-2"} -->
+/// ```
 ///
 /// [guide]: docs/guide/template-syntax.html#ngIf
 @Directive(selector: "[ngIf]", inputs: const ["ngIf"])

--- a/lib/src/common/directives/ng_if.dart
+++ b/lib/src/common/directives/ng_if.dart
@@ -11,10 +11,14 @@ import 'package:angular2/core.dart'
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgIf-1"} -->
+/// <div *ngIf="currentHero != null">Hello, {{currentHero.firstName}}</div>
 /// ```
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="Template-2"} -->
+/// <template [ngIf]="currentHero != null">
+///   <hero-detail [hero]="currentHero"></hero-detail>
+/// </template>
 /// ```
 ///
 /// [guide]: docs/guide/template-syntax.html#ngIf

--- a/lib/src/common/directives/ng_style.dart
+++ b/lib/src/common/directives/ng_style.dart
@@ -24,10 +24,31 @@ import '../../core/change_detection/differs/default_keyvalue_differ.dart'
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgStyle"} -->
+/// <div>
+///   <p [ngStyle]="setStyle()" #styleP>Change style of this text!</p>
+/// 
+///   <label>Italic: <input type="checkbox" [(ngModel)]="isItalic"></label> |
+///   <label>Bold: <input type="checkbox" [(ngModel)]="isBold"></label> |
+///   <label>Size: <input type="text" [(ngModel)]="fontSize"></label>
+/// 
+///   <p>Style set to: <code>'{{styleP.style.cssText}}'</code></p>
+/// </div>
 /// ```
 ///
 /// ```dart
 /// // {@source "docs/template-syntax/lib/app_component.dart" region="NgStyle"}
+/// bool isItalic = false;
+/// bool isBold = false;
+/// String fontSize = 'large';
+/// String fontSizePx = '14';
+/// 
+/// Map<String, String> setStyle() {
+///   return {
+///     'font-style': isItalic ? 'italic' : 'normal',
+///     'font-weight': isBold ? 'bold' : 'normal',
+///     'font-size': fontSize
+///   };
+/// }
 /// ```
 ///
 /// In this example, user changes to the `<input>` elements result in updates

--- a/lib/src/common/directives/ng_style.dart
+++ b/lib/src/common/directives/ng_style.dart
@@ -22,9 +22,13 @@ import '../../core/change_detection/differs/default_keyvalue_differ.dart'
 /// the relevant excerpts from the example's template and the corresponding
 /// component class:
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgStyle}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgStyle"} -->
+/// ```
 ///
-/// {@example docs/template-syntax/lib/app_component.dart region=NgStyle}
+/// ```dart
+/// // {@source "docs/template-syntax/lib/app_component.dart" region="NgStyle"}
+/// ```
 ///
 /// In this example, user changes to the `<input>` elements result in updates
 /// to the corresponding style properties of the first paragraph.

--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -40,6 +40,23 @@ class SwitchView {
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgSwitch-expanded"} -->
+///     <span [ngSwitch]="toeChoice">
+/// 
+///       <!-- with *NgSwitch -->
+///       <span *ngSwitchWhen="'Eenie'">Eenie</span>
+///       <span *ngSwitchWhen="'Meanie'">Meanie</span>
+///       <span *ngSwitchWhen="'Miney'">Miney</span>
+///       <span *ngSwitchWhen="'Moe'">Moe</span>
+///       <span *ngSwitchDefault>other</span>
+/// 
+///       <!-- with <template> -->
+///       <template [ngSwitchWhen]="'Eenie'"><span>Eenie</span></template>
+///       <template [ngSwitchWhen]="'Meanie'"><span>Meanie</span></template>
+///       <template [ngSwitchWhen]="'Miney'"><span>Miney</span></template>
+///       <template [ngSwitchWhen]="'Moe'"><span>Moe</span></template>
+///       <template ngSwitchDefault><span>other</span></template>
+/// 
+///     </span>
 /// ```
 ///
 /// Try the [live example][ex].

--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -38,7 +38,9 @@ class SwitchView {
 ///
 /// ### Examples
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgSwitch-expanded}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgSwitch-expanded"} -->
+/// ```
 ///
 /// Try the [live example][ex].
 /// See the [Template Syntax section on `ngSwitch`][guide] for more details.

--- a/lib/src/common/forms/directives/ng_model.dart
+++ b/lib/src/common/forms/directives/ng_model.dart
@@ -43,12 +43,16 @@ const formControlBinding = const Provider(NgControl, useExisting: NgModel);
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgModel-1"} -->
+/// <input [(ngModel)]="currentHero.firstName">
 /// ```
 ///
 /// This is equivalent to having separate bindings:
 ///
 /// ```html
 /// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgModel-3"} -->
+/// <input
+///   [ngModel]="currentHero.firstName"
+///   (ngModelChange)="currentHero.firstName=$event">
 /// ```
 ///
 /// Try the [live example][ex].

--- a/lib/src/common/forms/directives/ng_model.dart
+++ b/lib/src/common/forms/directives/ng_model.dart
@@ -41,11 +41,15 @@ const formControlBinding = const Provider(NgControl, useExisting: NgModel);
 ///
 /// ### Examples
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgModel-1}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgModel-1"} -->
+/// ```
 ///
 /// This is equivalent to having separate bindings:
 ///
-/// {@example docs/template-syntax/lib/app_component.html region=NgModel-3}
+/// ```html
+/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgModel-3"} -->
+/// ```
 ///
 /// Try the [live example][ex].
 /// [ex]: examples/template-syntax/#ngModel

--- a/lib/src/common/pipes/async_pipe.dart
+++ b/lib/src/common/pipes/async_pipe.dart
@@ -41,6 +41,43 @@ Future<dynamic> ___unused;
 ///
 /// ```dart
 /// // {@source "common/pipes/lib/async_pipe.dart" region="AsyncPipe"}
+/// @Component(
+///     selector: 'async-greeter',
+///     template: '''
+///       <div>
+///         <p>Wait for it ... {{ greeting | async }}</p>
+///         <button [disabled]="!done" (click)="tryAgain()">Try Again!</button>
+///       </div>''')
+/// class AsyncGreeterPipe {
+///   static const _delay = const Duration(seconds: 2);
+/// 
+///   Future<String> greeting;
+///   bool done;
+/// 
+///   AsyncGreeterPipe() {
+///     tryAgain();
+///   }
+/// 
+///   String greet() {
+///     done = true;
+///     return "Hi!";
+///   }
+/// 
+///   void tryAgain() {
+///     done = false;
+///     greeting = new Future<String>.delayed(_delay, greet);
+///   }
+/// }
+/// 
+/// @Component(
+///     selector: 'async-time',
+///     template: "<p>Time: {{ time | async | date:'mediumTime'}}</p>") //
+/// class AsyncTimePipe {
+///   static const _delay = const Duration(seconds: 1);
+///   final Stream<DateTime> time =
+///       new Stream.periodic(_delay, (_) => new DateTime.now());
+/// }
+/// 
 /// ```
 ///
 @Pipe("async", pure: false)

--- a/lib/src/common/pipes/async_pipe.dart
+++ b/lib/src/common/pipes/async_pipe.dart
@@ -39,7 +39,9 @@ Future<dynamic> ___unused;
 ///
 /// ### Example
 ///
-/// {@example common/pipes/lib/async_pipe.dart region='AsyncPipe'}
+/// ```dart
+/// // {@source "common/pipes/lib/async_pipe.dart" region="AsyncPipe"}
+/// ```
 ///
 @Pipe("async", pure: false)
 @Injectable()

--- a/lib/src/common/pipes/slice_pipe.dart
+++ b/lib/src/common/pipes/slice_pipe.dart
@@ -46,7 +46,9 @@ import 'invalid_pipe_argument_exception.dart' show InvalidPipeArgumentException;
 ///
 /// This `ngFor` example:
 ///
-/// {@example core/pipes/ts/slice_pipe/slice_pipe_example.ts region='SlicePipe_list'}
+/// ```dart
+/// // {@disabled-source "core/pipes/ts/slice_pipe/slice_pipe_example.ts" region="SlicePipe_list"}
+/// ```
 ///
 /// produces the following:
 ///

--- a/lib/src/core/application_ref.dart
+++ b/lib/src/core/application_ref.dart
@@ -184,7 +184,8 @@ abstract class ApplicationRef {
   /// selector and kicks off automatic change detection to finish initializing the component.
   ///
   /// ### Example
-  ///     {@example core/ts/platform/platform.ts region='longform'}
+  /// 
+  /// {@example core/ts/platform/platform.ts region='longform'}
   ///
   ComponentRef bootstrap(ComponentFactory componentFactory);
 

--- a/lib/src/core/application_ref.dart
+++ b/lib/src/core/application_ref.dart
@@ -185,7 +185,9 @@ abstract class ApplicationRef {
   ///
   /// ### Example
   /// 
-  /// {@example core/ts/platform/platform.ts region='longform'}
+/// ```dart
+/// // {@disabled-source "core/ts/platform/platform.ts" region="longform"}
+/// ```
   ///
   ComponentRef bootstrap(ComponentFactory componentFactory);
 

--- a/lib/src/core/di/provider.dart
+++ b/lib/src/core/di/provider.dart
@@ -171,7 +171,9 @@ class Provider {
 ///
 /// ### Example
 ///
-/// {@example docs/toh-6/web/main.dart}
+/// ```dart
+/// // {@source "docs/toh-6/web/main.dart"}
+/// ```
 ///
 /// [di]: docs/guide/dependency-injection.html#injector-providers
 Provider provide(token,

--- a/lib/src/core/di/provider.dart
+++ b/lib/src/core/di/provider.dart
@@ -173,6 +173,19 @@ class Provider {
 ///
 /// ```dart
 /// // {@source "docs/toh-6/web/main.dart"}
+/// import 'package:angular2/core.dart';
+/// import 'package:angular2/platform/browser.dart';
+/// import 'package:angular_tour_of_heroes/app_component.dart';
+/// import 'package:angular_tour_of_heroes/in_memory_data_service.dart';
+/// import 'package:http/http.dart';
+/// 
+/// void main() {
+///   bootstrap(AppComponent,
+///     [provide(Client, useClass: InMemoryDataService)]
+///     // Using a real back end? Import browser_client.dart and change the above to
+///     // [provide(Client, useFactory: () => new BrowserClient(), deps: [])]
+///   );
+/// }
 /// ```
 ///
 /// [di]: docs/guide/dependency-injection.html#injector-providers

--- a/lib/src/core/metadata/lifecycle_hooks.dart
+++ b/lib/src/core/metadata/lifecycle_hooks.dart
@@ -47,7 +47,9 @@ var LIFECYCLE_HOOKS_VALUES = [
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/on_changes_component.dart region=ng-on-changes}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/on_changes_component.dart" region="ng-on-changes"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#onchanges
 /// [ex]: examples/lifecycle-hooks#onchanges
@@ -66,7 +68,9 @@ abstract class OnChanges {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/spy_directive.dart region=spy-directive}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#oninit
 /// [ex]: examples/lifecycle-hooks#spy
@@ -100,7 +104,9 @@ abstract class OnInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/do_check_component.dart region=ng-do-check}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/do_check_component.dart" region="ng-do-check"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#docheck
 /// [ex]: examples/lifecycle-hooks#docheck
@@ -117,7 +123,9 @@ abstract class DoCheck {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/spy_directive.dart region=spy-directive}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#ondestroy
 /// [ex]: examples/lifecycle-hooks#spy
@@ -132,9 +140,13 @@ abstract class OnDestroy {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/after_content_component.dart region=template}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"}
+/// ```
 ///
-/// {@example docs/lifecycle-hooks/lib/after_content_component.dart region=hooks}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#aftercontent
 /// [ex]: examples/lifecycle-hooks#after-content
@@ -149,9 +161,13 @@ abstract class AfterContentInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/after_content_component.dart region=template}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"}
+/// ```
 ///
-/// {@example docs/lifecycle-hooks/lib/after_content_component.dart region=hooks}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#aftercontent
 /// [ex]: examples/lifecycle-hooks#after-content
@@ -166,9 +182,13 @@ abstract class AfterContentChecked {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/after_view_component.dart region=template}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"}
+/// ```
 ///
-/// {@example docs/lifecycle-hooks/lib/after_view_component.dart region=hooks}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#afterview
 /// [ex]: examples/lifecycle-hooks#after-view
@@ -183,9 +203,13 @@ abstract class AfterViewInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// {@example docs/lifecycle-hooks/lib/after_view_component.dart region=template}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"}
+/// ```
 ///
-/// {@example docs/lifecycle-hooks/lib/after_view_component.dart region=hooks}
+/// ```dart
+/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"}
+/// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#afterview
 /// [ex]: examples/lifecycle-hooks#after-view

--- a/lib/src/core/metadata/lifecycle_hooks.dart
+++ b/lib/src/core/metadata/lifecycle_hooks.dart
@@ -49,6 +49,14 @@ var LIFECYCLE_HOOKS_VALUES = [
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/on_changes_component.dart" region="ng-on-changes"}
+/// ngOnChanges(Map<String, SimpleChange> changes) {
+///   changes.forEach((String propName, SimpleChange change) {
+///     String cur = JSON.encode(change.currentValue);
+///     String prev =
+///         change.isFirstChange() ? "{}" : JSON.encode(change.previousValue);
+///     changeLog.add('$propName: currentValue = $cur, previousValue = $prev');
+///   });
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#onchanges
@@ -70,6 +78,20 @@ abstract class OnChanges {
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"}
+/// // Spy on any element to which it is applied.
+/// // Usage: <div mySpy>...</div>
+/// @Directive(selector: '[mySpy]')
+/// class SpyDirective implements OnInit, OnDestroy {
+///   final LoggerService _logger;
+/// 
+///   SpyDirective(this._logger);
+/// 
+///   ngOnInit() => _logIt('onInit');
+/// 
+///   ngOnDestroy() => _logIt('onDestroy');
+/// 
+///   _logIt(String msg) => _logger.log('Spy #${_nextId++} $msg');
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#oninit
@@ -106,6 +128,38 @@ abstract class OnInit {
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/do_check_component.dart" region="ng-do-check"}
+/// ngDoCheck() {
+///   if (hero.name != oldHeroName) {
+///     changeDetected = true;
+///     changeLog.add(
+///         'DoCheck: Hero name changed to "${hero.name}" from "$oldHeroName"');
+///     oldHeroName = hero.name;
+///   }
+/// 
+///   if (power != oldPower) {
+///     changeDetected = true;
+///     changeLog.add('DoCheck: Power changed to "$power" from "$oldPower"');
+///     oldPower = power;
+///   }
+/// 
+///   if (changeDetected) {
+///     noChangeCount = 0;
+///   } else {
+///     // log that hook was called when there was no relevant change.
+///     var count = noChangeCount += 1;
+///     var noChangeMsg =
+///         'DoCheck called ${count}x when no change to hero or power';
+///     if (count == 1) {
+///       // add new "no change" message
+///       changeLog.add(noChangeMsg);
+///     } else {
+///       // update last "no change" message
+///       changeLog[changeLog.length - 1] = noChangeMsg;
+///     }
+///   }
+/// 
+///   changeDetected = false;
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#docheck
@@ -125,6 +179,20 @@ abstract class DoCheck {
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"}
+/// // Spy on any element to which it is applied.
+/// // Usage: <div mySpy>...</div>
+/// @Directive(selector: '[mySpy]')
+/// class SpyDirective implements OnInit, OnDestroy {
+///   final LoggerService _logger;
+/// 
+///   SpyDirective(this._logger);
+/// 
+///   ngOnInit() => _logIt('onInit');
+/// 
+///   ngOnDestroy() => _logIt('onDestroy');
+/// 
+///   _logIt(String msg) => _logger.log('Spy #${_nextId++} $msg');
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#ondestroy
@@ -142,10 +210,41 @@ abstract class OnDestroy {
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"}
+/// template: '''
+///   <div>-- projected content begins --</div>
+///     <ng-content></ng-content>
+///   <div>-- projected content ends --</div>
+///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>
+/// '''
 /// ```
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"}
+/// class AfterContentComponent implements AfterContentChecked, AfterContentInit {
+///   String _prevHero = '';
+///   String comment = '';
+/// 
+///   // Query for a CONTENT child of type `ChildComponent`
+///   @ContentChild(ChildComponent) ChildComponent contentChild;
+/// 
+///   ngAfterContentInit() {
+///     // contentChild is set after the content has been initialized
+///     _logIt('AfterContentInit');
+///     _doSomething();
+///   }
+/// 
+///   ngAfterContentChecked() {
+///     // contentChild is updated after the content has been checked
+///     if (_prevHero == contentChild?.hero) {
+///       _logIt('AfterContentChecked (no change)');
+///     } else {
+///       _prevHero = contentChild?.hero;
+///       _logIt('AfterContentChecked');
+///       _doSomething();
+///     }
+///   }
+///   // ...
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#aftercontent
@@ -163,10 +262,41 @@ abstract class AfterContentInit {
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"}
+/// template: '''
+///   <div>-- projected content begins --</div>
+///     <ng-content></ng-content>
+///   <div>-- projected content ends --</div>
+///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>
+/// '''
 /// ```
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"}
+/// class AfterContentComponent implements AfterContentChecked, AfterContentInit {
+///   String _prevHero = '';
+///   String comment = '';
+/// 
+///   // Query for a CONTENT child of type `ChildComponent`
+///   @ContentChild(ChildComponent) ChildComponent contentChild;
+/// 
+///   ngAfterContentInit() {
+///     // contentChild is set after the content has been initialized
+///     _logIt('AfterContentInit');
+///     _doSomething();
+///   }
+/// 
+///   ngAfterContentChecked() {
+///     // contentChild is updated after the content has been checked
+///     if (_prevHero == contentChild?.hero) {
+///       _logIt('AfterContentChecked (no change)');
+///     } else {
+///       _prevHero = contentChild?.hero;
+///       _logIt('AfterContentChecked');
+///       _doSomething();
+///     }
+///   }
+///   // ...
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#aftercontent
@@ -184,10 +314,39 @@ abstract class AfterContentChecked {
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"}
+/// template: '''
+///   <div>-- child view begins --</div>
+///     <my-child-view></my-child-view>
+///   <div>-- child view ends --</div>
+///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>''',
 /// ```
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"}
+/// class AfterViewComponent implements AfterViewChecked, AfterViewInit {
+///   var _prevHero = '';
+/// 
+///   // Query for a VIEW child of type `ChildViewComponent`
+///   @ViewChild(ChildViewComponent) ChildViewComponent viewChild;
+/// 
+///   ngAfterViewInit() {
+///     // viewChild is set after the view has been initialized
+///     _logIt('AfterViewInit');
+///     _doSomething();
+///   }
+/// 
+///   ngAfterViewChecked() {
+///     // viewChild is updated after the view has been checked
+///     if (_prevHero == viewChild.hero) {
+///       _logIt('AfterViewChecked (no change)');
+///     } else {
+///       _prevHero = viewChild.hero;
+///       _logIt('AfterViewChecked');
+///       _doSomething();
+///     }
+///   }
+///   // ...
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#afterview
@@ -205,10 +364,39 @@ abstract class AfterViewInit {
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"}
+/// template: '''
+///   <div>-- child view begins --</div>
+///     <my-child-view></my-child-view>
+///   <div>-- child view ends --</div>
+///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>''',
 /// ```
 ///
 /// ```dart
 /// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"}
+/// class AfterViewComponent implements AfterViewChecked, AfterViewInit {
+///   var _prevHero = '';
+/// 
+///   // Query for a VIEW child of type `ChildViewComponent`
+///   @ViewChild(ChildViewComponent) ChildViewComponent viewChild;
+/// 
+///   ngAfterViewInit() {
+///     // viewChild is set after the view has been initialized
+///     _logIt('AfterViewInit');
+///     _doSomething();
+///   }
+/// 
+///   ngAfterViewChecked() {
+///     // viewChild is updated after the view has been checked
+///     if (_prevHero == viewChild.hero) {
+///       _logIt('AfterViewChecked (no change)');
+///     } else {
+///       _prevHero = viewChild.hero;
+///       _logIt('AfterViewChecked');
+///       _doSomething();
+///     }
+///   }
+///   // ...
+/// }
 /// ```
 ///
 /// [docs]: docs/guide/lifecycle-hooks.html#afterview

--- a/lib/src/router/directives/router_link.dart
+++ b/lib/src/router/directives/router_link.dart
@@ -10,12 +10,19 @@ import "../router.dart" show Router;
 ///
 /// ```dart
 /// // {@source "docs/toh-5/lib/app_component.dart" region="heroes"}
+/// @RouteConfig(const [
+///   const Route(path: '/heroes', name: 'Heroes', component: HeroesComponent)
+/// ])
 /// ```
 ///
 /// When linking to this `Heroes` route, you can write:
 ///
 /// ```dart
 /// // {@source "docs/toh-5/lib/app_component_1.dart" region="template-v2"}
+/// template: '''
+///   <h1>{{title}}</h1>
+///   <a [routerLink]="['Heroes']">Heroes</a>
+///   <router-outlet></router-outlet>''',
 /// ```
 ///
 /// RouterLink expects the value to be an array of route names, followed by the params

--- a/lib/src/router/directives/router_link.dart
+++ b/lib/src/router/directives/router_link.dart
@@ -8,11 +8,15 @@ import "../router.dart" show Router;
 ///
 /// Consider the following route configuration:
 ///
-/// {@example docs/toh-5/lib/app_component.dart region=heroes}
+/// ```dart
+/// // {@source "docs/toh-5/lib/app_component.dart" region="heroes"}
+/// ```
 ///
 /// When linking to this `Heroes` route, you can write:
 ///
-/// {@example docs/toh-5/lib/app_component_1.dart region=template-v2}
+/// ```dart
+/// // {@source "docs/toh-5/lib/app_component_1.dart" region="template-v2"}
+/// ```
 ///
 /// RouterLink expects the value to be an array of route names, followed by the params
 /// for that level of routing. For instance `['/Team', {teamId: 1}, 'User', {userId: 2}]`

--- a/lib/src/router/directives/router_outlet.dart
+++ b/lib/src/router/directives/router_outlet.dart
@@ -31,6 +31,13 @@ var _resolveToTrue = new Future.value(true);
 ///
 /// ```dart
 /// // {@source "docs/toh-5/lib/app_component.dart" region="template"}
+/// template: '''
+///   <h1>{{title}}</h1>
+///   <nav>
+///     <a [routerLink]="['Dashboard']">Dashboard</a>
+///     <a [routerLink]="['Heroes']">Heroes</a>
+///   </nav>
+///   <router-outlet></router-outlet>''',
 /// ```
 ///
 /// [routing]: docs/tutorial/toh-pt5.html#router-outlet

--- a/lib/src/router/directives/router_outlet.dart
+++ b/lib/src/router/directives/router_outlet.dart
@@ -29,7 +29,9 @@ var _resolveToTrue = new Future.value(true);
 ///
 /// Here is an example from the [tutorial on routing][routing]:
 ///
-/// {@example docs/toh-5/lib/app_component.dart region=template}
+/// ```dart
+/// // {@source "docs/toh-5/lib/app_component.dart" region="template"}
+/// ```
 ///
 /// [routing]: docs/tutorial/toh-pt5.html#router-outlet
 @Directive(selector: "router-outlet")

--- a/lib/src/router/interfaces.dart
+++ b/lib/src/router/interfaces.dart
@@ -15,7 +15,9 @@ import 'instruction.dart' show ComponentInstruction;
 /// instantiate and activate child components.
 ///
 /// ### Example
-/// {@example router/ts/on_activate/on_activate_example.ts region='routerOnActivate'}
+/// ```dart
+/// // {@disabled-source "router/ts/on_activate/on_activate_example.ts" region="routerOnActivate"}
+/// ```
 abstract class OnActivate {
   dynamic /* dynamic | Future< dynamic > */ routerOnActivate(
       ComponentInstruction nextInstruction,
@@ -34,7 +36,9 @@ abstract class OnActivate {
 /// previous route or `null`.
 ///
 /// ### Example
-/// {@example router/ts/reuse/reuse_example.ts region='reuseCmp'}
+/// ```dart
+/// // {@disabled-source "router/ts/reuse/reuse_example.ts" region="reuseCmp"}
+/// ```
 abstract class OnReuse {
   dynamic /* dynamic | Future< dynamic > */ routerOnReuse(
       ComponentInstruction nextInstruction,
@@ -53,7 +57,9 @@ abstract class OnReuse {
 /// If `routerOnDeactivate` returns a promise, the route change will wait until the promise settles.
 ///
 /// ### Example
-/// {@example router/ts/on_deactivate/on_deactivate_example.ts region='routerOnDeactivate'}
+/// ```dart
+/// // {@disabled-source "router/ts/on_deactivate/on_deactivate_example.ts" region="routerOnDeactivate"}
+/// ```
 abstract class OnDeactivate {
   dynamic /* dynamic | Future< dynamic > */ routerOnDeactivate(
       ComponentInstruction nextInstruction,
@@ -77,7 +83,9 @@ abstract class OnDeactivate {
 /// If `routerCanReuse` throws or rejects, the navigation will be cancelled.
 ///
 /// ### Example
-/// {@example router/ts/reuse/reuse_example.ts region='reuseCmp'}
+/// ```dart
+/// // {@disabled-source "router/ts/reuse/reuse_example.ts" region="reuseCmp"}
+/// ```
 abstract class CanReuse {
   dynamic /* bool | Future< bool > */ routerCanReuse(
       ComponentInstruction nextInstruction,
@@ -100,7 +108,9 @@ abstract class CanReuse {
 /// If `routerCanDeactivate` throws or rejects, the navigation is also cancelled.
 ///
 /// ### Example
-/// {@example router/ts/can_deactivate/can_deactivate_example.ts region='routerCanDeactivate'}
+/// ```dart
+/// // {@disabled-source "router/ts/can_deactivate/can_deactivate_example.ts" region="routerCanDeactivate"}
+/// ```
 abstract class CanDeactivate {
   dynamic /* bool | Future< bool > */ routerCanDeactivate(
       ComponentInstruction nextInstruction,

--- a/lib/src/router/route_config/route_config_impl.dart
+++ b/lib/src/router/route_config/route_config_impl.dart
@@ -15,6 +15,16 @@ Future<dynamic> ___make_dart_analyzer_happy;
 ///
 /// ```dart
 /// // {@source "docs/toh-5/lib/app_component.dart" region="routes"}
+/// @RouteConfig(const [
+///   const Route(
+///       path: '/dashboard',
+///       name: 'Dashboard',
+///       component: DashboardComponent,
+///       useAsDefault: true),
+///   const Route(
+///       path: '/detail/:id', name: 'HeroDetail', component: HeroDetailComponent),
+///   const Route(path: '/heroes', name: 'Heroes', component: HeroesComponent)
+/// ])
 /// ```
 ///
 /// [routing]: docs/tutorial/toh-pt5.html#configure-routes

--- a/lib/src/router/route_config/route_config_impl.dart
+++ b/lib/src/router/route_config/route_config_impl.dart
@@ -13,7 +13,9 @@ Future<dynamic> ___make_dart_analyzer_happy;
 ///
 /// Here is an example from the [tutorial on routing][routing]:
 ///
-/// {@example docs/toh-5/lib/app_component.dart region=routes}
+/// ```dart
+/// // {@source "docs/toh-5/lib/app_component.dart" region="routes"}
+/// ```
 ///
 /// [routing]: docs/tutorial/toh-pt5.html#configure-routes
 class RouteConfig {


### PR DESCRIPTION
Here is an example from the [staged site](https://angulardart-org-dev.firebaseapp.com/angular): [NgStyle](https://angulardart-org-dev.firebaseapp.com/angular/api/angular2.common/NgStyle-class).

Contributes to https://github.com/dart-lang/site-webdev/issues/338

Note that `@example` directives that referred to `.ts` code have been written as `{@disabled-source ...}` entries. These will be converted to proper `@source` entries in a follow-up commit.

cc @kwalrath @matanlurey @thso @kevmoo 