### PR TITLE
API doc updates: slice pipe and other misc adjustments

### DIFF
--- a/lib/platform/browser.dart
+++ b/lib/platform/browser.dart
@@ -128,8 +128,8 @@ PlatformRef browserPlatform() {
 /// void main() {
 ///   bootstrap(AppComponent,
 ///     [provide(Client, useClass: InMemoryDataService)]
-///     // Using a real back end? Import browser_client.dart and change the
-///     // above to
+///     // Using a real back end?
+///     // Import browser_client.dart and change the above to:
 ///     // [provide(Client, useFactory: () => new BrowserClient(), deps: [])]
 ///   );
 /// }

--- a/lib/src/common/pipes/slice_pipe.dart
+++ b/lib/src/common/pipes/slice_pipe.dart
@@ -4,56 +4,51 @@ import 'package:angular2/di.dart' show Injectable, PipeTransform, Pipe;
 
 import 'invalid_pipe_argument_exception.dart' show InvalidPipeArgumentException;
 
-/// Creates a new List or String containing only a subset (slice) of the
-/// elements.
-///
-/// The starting index of the subset to return is specified by the `start`
-/// parameter.
-///
-/// The ending index of the subset to return is specified by the optional `end`
-/// parameter.
+/// Creates a new [List] or [String] containing a subset (slice) of the elements.
 ///
 /// ### Usage
 ///
 ///     expression | slice:start[:end]
 ///
-/// All behavior is based on the expected behavior of the JavaScript API
-/// Array.prototype.slice() and String.prototype.slice()
+/// The input _expression_ must be a [List] or [String].
 ///
-/// Where the input expression is a [List] or [String], and `start` is:
-///
-/// - **a positive integer**: return the item at _start_ index and all items
-/// after in the list or string expression.
-/// - **a negative integer**: return the item at _start_ index from the end and
-/// all items after in the list or string expression.
-/// - **`|start|` greater than the size of the expression**: return an empty
-/// list or string.
-/// - **`|start|` negative greater than the size of the expression**: return
-/// entire list or string expression.
-///
-/// and where `end` is:
-///
-/// - **omitted**: return all items until the end of the input
-/// - **a positive integer**: return all items before _end_ index of the list or
-/// string expression.
-/// - **a negative integer**: return all items before _end_ index from the end
-/// of the list or string expression.
+/// - _start_: the starting index of the subset to return.
+///   - **a positive integer**: return the item at `start` index and all
+///     items after in the list or string expression.
+///   - **a negative integer**: return the item at `start` index from the end
+///     and all items after in the list or string expression.
+///   - **if positive and greater than the size of the expression**:
+///     return an empty list or string.
+///   - **if negative and greater than the size of the expression**:
+///     return entire list or string.
+/// - _end_: The ending index of the subset to return.
+///   - **omitted**: return all items until the end.
+///   - **if positive**: return all items before `end` index of the list or string.
+///   - **if negative**: return all items before `end` index
+///     from the end of the list or string.
 ///
 /// When operating on a [List], the returned list is always a copy even when all
 /// the elements are being returned.
 ///
-/// ## List Example
+/// ### Examples
 ///
-/// This `ngFor` example:
+/// ```html
+/// <!-- {@source "common/pipes/lib/app_component.html" region="slice"} -->
+/// <ul>
+///     <li *ngFor="let i of ['a', 'b', 'c', 'd'] | slice:1:3">{{i}}</li>
+/// </ul>
 ///
-/// ```dart
-/// // {@disabled-source "core/pipes/ts/slice_pipe/slice_pipe_example.ts" region="SlicePipe_list"}
+/// <pre>
+///   {{str}}[0:4]:   '{{str | slice:0:4}}' --> 'abcd'
+///   {{str}}[4:0]:   '{{str | slice:4:0}}' --> ''
+///   {{str}}[-4]:    '{{str | slice:-4}}' --> 'ghij'
+///   {{str}}[-4:-2]: '{{str | slice:-4:-2}}' --> 'gh'
+///   {{str}}[-100]:  '{{str | slice:-100}}' --> 'abcdefghij'
+///   {{str}}[100]:   '{{str | slice:100}}' --> ''
+/// </pre>
 /// ```
-///
-/// produces the following:
-///
-///     <li>b</li>
-///     <li>c</li>
+/// The first example generates two `<li>` elements with text `b` and `c`.
+/// The second example uses the string `'abcdefghij'`.
 @Pipe("slice", pure: false)
 @Injectable()
 class SlicePipe implements PipeTransform {

--- a/lib/src/core/di/provider.dart
+++ b/lib/src/core/di/provider.dart
@@ -182,7 +182,8 @@ class Provider {
 /// void main() {
 ///   bootstrap(AppComponent,
 ///     [provide(Client, useClass: InMemoryDataService)]
-///     // Using a real back end? Import browser_client.dart and change the above to
+///     // Using a real back end?
+///     // Import browser_client.dart and change the above to:
 ///     // [provide(Client, useFactory: () => new BrowserClient(), deps: [])]
 ///   );
 /// }


### PR DESCRIPTION
- Slice pipe: the list of cases for `start` and `end` come from the updated TS docs.
- The misc adjustments to other files are only due to code-fragment comment line reformatting (adjusted line breaks).

Contributes to https://github.com/dart-lang/site-webdev/issues/362

The updated Slice pipe page:
> ![screen shot 2017-02-10 at 3 34 25 pm](https://cloud.githubusercontent.com/assets/4140793/22848054/7c94f070-efa6-11e6-8fec-5c63e2480fd7.png)

cc @kwalrath 