### PR TITLE
ApplicationRef.bootstrap: drop reference to TS code

### DIFF
--- a/lib/src/core/application_ref.dart
+++ b/lib/src/core/application_ref.dart
@@ -177,18 +177,9 @@ abstract class ApplicationRef {
 
   /// Bootstrap a new component at the root level of the application.
   ///
-  /// ### Bootstrap process
-  ///
   /// When bootstrapping a new root component into an application, Angular mounts the
   /// specified application component onto DOM elements identified by the [componentType]'s
   /// selector and kicks off automatic change detection to finish initializing the component.
-  ///
-  /// ### Example
-  ///
-  /// ```dart
-  /// // {@disabled-source "core/ts/platform/platform.ts" region="longform"}
-  /// ```
-  ///
   ComponentRef bootstrap(ComponentFactory componentFactory);
 
   /// Retrieve the application [Injector].


### PR DESCRIPTION
This isn’t the usual way that apps are bootstrapped, so just drop the TS code reference.

cc @kwalrath 