### PR TITLE
docs: Fix indentation for bullet lists

### DIFF
--- a/lib/src/compiler/url_resolver.dart
+++ b/lib/src/compiler/url_resolver.dart
@@ -29,10 +29,10 @@ class UrlResolver {
 
   /// Resolves the `url` given the `baseUrl`:
   /// - when the `url` is null, the `baseUrl` is returned,
-  /// - if `url` is relative ('path/to/here', './path/to/here'), the resolved url is a combination of
-  /// `baseUrl` and `url`,
-  /// - if `url` is absolute (it has a scheme: 'http://', 'https://' or start with '/'), the `url` is
-  /// returned as is (ignoring the `baseUrl`)
+  /// - if `url` is relative ('path/to/here', './path/to/here'), the resolved
+  ///   url is a combination of `baseUrl` and `url`,
+  /// - if `url` is absolute (it has a scheme: 'http://', 'https://' or start
+  ///   with '/'), the `url` is returned as is (ignoring the `baseUrl`)
   ///
   /// @param {string} baseUrl
   /// @param {string} url

--- a/lib/src/core/di/injector.dart
+++ b/lib/src/core/di/injector.dart
@@ -25,7 +25,7 @@ abstract class Injector {
   /// Retrieves an instance from the injector based on the provided token.
   /// If not found:
   /// - Throws [NoProviderError] if no `notFoundValue` that is not equal to
-  /// Injector.THROW_IF_NOT_FOUND is given
+  ///   Injector.THROW_IF_NOT_FOUND is given
   /// - Returns the `notFoundValue` otherwise
   ///
   /// ### Example ([live demo](http://plnkr.co/edit/HeXSHg?p=preview))

--- a/lib/src/core/metadata.dart
+++ b/lib/src/core/metadata.dart
@@ -132,7 +132,7 @@ class Directive extends Injectable {
   ///
   /// - _directiveProperty_ specifies the component property that emits events.
   /// - _bindingProperty_ specifies the DOM property the event handler is
-  /// attached to.
+  ///   attached to.
   ///
   /// ```dart
   /// @Directive(
@@ -831,10 +831,10 @@ class ViewQuery extends Query {
 /// to be selected.
 ///
 /// - If the argument is a [Type], directives or components with the type will
-/// be bound.
+///   be bound.
 /// - If the argument is a [String], the string is interpreted as a list of
-/// comma-separated selectors.  For each selector, an element containing the
-/// matching template variable (e.g. `#child`) will be bound.
+///   comma-separated selectors.  For each selector, an element containing the
+///   matching template variable (e.g. `#child`) will be bound.
 ///
 /// View children are set before the `ngAfterViewInit` callback is called.
 ///
@@ -916,10 +916,10 @@ class ViewChildren extends ViewQuery {
 /// The `ViewChild` annotation takes an argument to select elements.
 ///
 /// - If the argument is a [Type], a directive or a component with the type will
-/// be bound.
+///   be bound.
 /// - If the argument is a [String], the string is interpreted as a selector. An
-/// element containing the matching template variable (e.g. `#child`) will be
-/// bound.
+///   element containing the matching template variable (e.g. `#child`) will be
+///   bound.
 ///
 /// In either case, `@ViewChild()` assigns the first (looking from above)
 /// element if there are multiple matches.

--- a/lib/src/router/route_config/route_config_decorator.dart
+++ b/lib/src/router/route_config/route_config_decorator.dart
@@ -58,11 +58,12 @@ abstract class AbstractRoute implements RouteDefinition {
 /// It has the following properties:
 /// - `path` is a string that uses the route matcher DSL.
 /// - `component` a component type.
-/// - `name` is an optional `CamelCase` string representing the name of the route.
-/// - `data` is an optional property of any type representing arbitrary route metadata for the given
-/// route. It is injectable via [RouteData].
-/// - `useAsDefault` is a boolean value. If `true`, the child route will be navigated to if no child
-/// route is specified during the navigation.
+/// - `name` is an optional `CamelCase` string representing the name of the
+///   route.
+/// - `data` is an optional property of any type representing arbitrary route
+///   metadata for the given route. It is injectable via [RouteData].
+/// - `useAsDefault` is a boolean value. If `true`, the child route will be
+///   navigated to if no child route is specified during the navigation.
 ///
 /// ### Example
 /// ```
@@ -100,8 +101,8 @@ class Route extends AbstractRoute {
 /// - `path` is a string that uses the route matcher DSL.
 /// - `component` a component type.
 /// - `name` is an optional `CamelCase` string representing the name of the route.
-/// - `data` is an optional property of any type representing arbitrary route metadata for the given
-/// route. It is injectable via [RouteData].
+/// - `data` is an optional property of any type representing arbitrary route
+///   metadata for the given route. It is injectable via [RouteData].
 ///
 /// ### Example
 /// ```
@@ -139,10 +140,10 @@ class AuxRoute extends AbstractRoute {
 /// - `path` is a string that uses the route matcher DSL.
 /// - `loader` is a function that returns a promise that resolves to a component.
 /// - `name` is an optional `CamelCase` string representing the name of the route.
-/// - `data` is an optional property of any type representing arbitrary route metadata for the given
-/// route. It is injectable via [RouteData].
-/// - `useAsDefault` is a boolean value. If `true`, the child route will be navigated to if no child
-/// route is specified during the navigation.
+/// - `data` is an optional property of any type representing arbitrary route
+///   metadata for the given route. It is injectable via [RouteData].
+/// - `useAsDefault` is a boolean value. If `true`, the child route will be
+///   navigated to if no child route is specified during the navigation.
 ///
 /// ### Example
 /// ```

--- a/lib/src/testing/test_injector.dart
+++ b/lib/src/testing/test_injector.dart
@@ -107,9 +107,9 @@ void resetBaseTestProviders() {
 /// ```
 ///
 /// Notes:
-/// - inject is currently a function because of some Traceur limitation the syntax should
-/// eventually
-///   becomes `it('...', @Inject (object: AClass, async: AsyncTestCompleter) => { ... });`
+/// - Inject is currently a function because of some Traceur limitation. The
+///   syntax should eventually become `it('...', @Inject (object: AClass, async:
+///   AsyncTestCompleter) => { ... });`
 FunctionWithParamTokens inject(List<dynamic> tokens, Function fn) {
   return new FunctionWithParamTokens(tokens, fn, false);
 }


### PR DESCRIPTION
Without this the next word from the following line isn't separated with a space from the last word of the current line.

For example this:
```
/// - If the argument is a [Type], directives or components with the type will
/// be bound.
```
becomes this (note the missing space between "will" and "be"):
* If the argument is a [Type], directives or components with the type willbe bound.

I've used `git grep` to search for all such occurrences and fixed them (hopefully all :wink:).