### PR TITLE
Support transitioning to `ngSwitchCase` from `ngSwitchWhen`

### DIFF
--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -156,7 +156,8 @@ class NgSwitch {
 ///
 /// See [NgSwitch] for more details and example.
 ///
-@Directive(selector: "[ngSwitchWhen]", inputs: const ["ngSwitchWhen"])
+@Directive(selector: "[ngSwitchWhen],[ngSwitchCase]",
+    inputs: const ["ngSwitchWhen","ngSwitchCase"])
 class NgSwitchWhen {
   // `_WHEN_DEFAULT` is used as a marker for a not yet initialized value
 
@@ -168,6 +169,11 @@ class NgSwitchWhen {
     this._switch = ngSwitch;
     this._view = new SwitchView(viewContainer, templateRef);
   }
+
+  set ngSwitchCase(dynamic value) {
+    ngSwitchWhen = value;
+  }
+
   set ngSwitchWhen(dynamic value) {
     if (identical(value, _value)) return;
     this._switch._onWhenValueChanged(this._value, value, this._view);

--- a/test/common/directives/ng_switch_test.dart
+++ b/test/common/directives/ng_switch_test.dart
@@ -15,8 +15,8 @@ void main() {
             (TestComponentBuilder tcb, AsyncTestCompleter completer) {
           var template = "<div>" +
               "<ul [ngSwitch]=\"switchValue\">" +
-              "<template ngSwitchWhen=\"a\"><li>when a</li></template>" +
-              "<template ngSwitchWhen=\"b\"><li>when b</li></template>" +
+              "<template ngSwitchCase=\"a\"><li>when a</li></template>" +
+              "<template ngSwitchCase=\"b\"><li>when b</li></template>" +
               "</ul></div>";
           tcb
               .overrideTemplate(TestComponent, template)
@@ -42,7 +42,7 @@ void main() {
             (TestComponentBuilder tcb, AsyncTestCompleter completer) {
           var template = "<div>" +
               "<ul [ngSwitch]=\"switchValue\">" +
-              "<li template=\"ngSwitchWhen 'a'\">when a</li>" +
+              "<li template=\"ngSwitchCase 'a'\">when a</li>" +
               "<li template=\"ngSwitchDefault\">when default</li>" +
               "</ul></div>";
           tcb
@@ -76,10 +76,10 @@ void main() {
             (TestComponentBuilder tcb, AsyncTestCompleter completer) {
           var template = "<div>" +
               "<ul [ngSwitch]=\"switchValue\">" +
-              "<template ngSwitchWhen=\"a\"><li>when a1;</li></template>" +
-              "<template ngSwitchWhen=\"b\"><li>when b1;</li></template>" +
-              "<template ngSwitchWhen=\"a\"><li>when a2;</li></template>" +
-              "<template ngSwitchWhen=\"b\"><li>when b2;</li></template>" +
+              "<template ngSwitchCase=\"a\"><li>when a1;</li></template>" +
+              "<template ngSwitchCase=\"b\"><li>when b1;</li></template>" +
+              "<template ngSwitchCase=\"a\"><li>when a2;</li></template>" +
+              "<template ngSwitchCase=\"b\"><li>when b2;</li></template>" +
               "<template ngSwitchDefault><li>when default1;</li></template>" +
               "<template ngSwitchDefault><li>when default2;</li></template>" +
               "</ul></div>";
@@ -109,8 +109,8 @@ void main() {
             (TestComponentBuilder tcb, AsyncTestCompleter completer) {
           var template = "<div>" +
               "<ul [ngSwitch]=\"switchValue\">" +
-              "<template [ngSwitchWhen]=\"when1\"><li>when 1;</li></template>" +
-              "<template [ngSwitchWhen]=\"when2\"><li>when 2;</li></template>" +
+              "<template [ngSwitchCase]=\"when1\"><li>when 1;</li></template>" +
+              "<template [ngSwitchCase]=\"when2\"><li>when 2;</li></template>" +
               "<template ngSwitchDefault><li>when default;</li></template>" +
               "</ul></div>";
           tcb


### PR DESCRIPTION
This PR introduces `ngSwitchCase` as an alternative directive name for `ngSwitchWhen`. This way we can start using the new name while apps using `ngSwitchWhen` can gradually be updated.

I've only changed a few tests to use `ngSwitchCase`. These test are passing (and no new tests are broken as far as I can tell).

Addresses #307

cc @kwalrath @kevmoo