### PR TITLE
Restore codegen tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   source_span: ^1.0.0
   stack_trace: ^1.6.5
 dev_dependencies:
-  angular_test: '1.0.0-alpha+5'
+  angular_test: '1.0.0-alpha+6'
   args: ^0.13.6
   build_runner: ^0.3.0
   build_test: ^0.4.0+1
@@ -38,10 +38,6 @@ transformers:
   - test/pub_serve:
       $include: test/**_test.dart
   - angular2/transform/codegen
-  - angular2/transform/reflection_remover:
-      $include:
-          - test/testing/ng_test_bed_test.dart
-          - test/security/safe_inner_html_test.dart
   - $dart2js:
       commandLineOptions:
         - '--show-package-warnings'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,9 @@ dev_dependencies:
 transformers:
   - test/pub_serve:
       $include: test/**_test.dart
-  - angular2/transform/codegen
+  - angular2/transform/codegen:
+      resolved_identifiers:
+          Logger: package:logging/logging.dart
   - $dart2js:
       commandLineOptions:
         - '--show-package-warnings'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,15 @@ transformers:
   - test/pub_serve:
       $include: test/**_test.dart
   - angular2/transform/codegen:
+      # These tests fail the transformer, but don't use it yet anyway.
+      $exclude:
+          - test/compiler/runtime_**.dart
+          - test/core/linker/change_detection_integration_test.dart
+          - test/core/linker/change_detection_lifecycle_test.dart
+          - test/core/linker/integration_test.dart
+          - test/core/linker/view_injector_integration_test.dart
+          - test/core/linker/query_integration_test.dart
+          - test/source_gen/**.dart
       resolved_identifiers:
           Logger: package:logging/logging.dart
   - $dart2js:

--- a/test/common/directives/if_test.dart
+++ b/test/common/directives/if_test.dart
@@ -8,7 +8,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'if_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('ngIf', () {
     tearDown(() => disposeAnyRunningTest());
 

--- a/test/common/directives/ng_template_outlet_test.dart
+++ b/test/common/directives/ng_template_outlet_test.dart
@@ -12,7 +12,13 @@ import 'package:angular2/src/testing/matchers.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'ng_template_outlet_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group("insert", () {
     tearDown(() => disposeAnyRunningTest());
     test("should do nothing if templateRef is null", () async {

--- a/test/common/forms/accessor_test.dart
+++ b/test/common/forms/accessor_test.dart
@@ -9,7 +9,13 @@ import 'package:angular2/src/common/forms/directives/control_value_accessor.dart
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'accessor_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('accessor test', () {
     tearDown(disposeAnyRunningTest);
 

--- a/test/compiler/preserve_whitespace_test.dart
+++ b/test/compiler/preserve_whitespace_test.dart
@@ -6,7 +6,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'preserve_whitespace_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   var testRoot;
   group('preservewhitespace', () {
     tearDown(() => disposeAnyRunningTest());

--- a/test/core/change_detection/component_state_test.dart
+++ b/test/core/change_detection/component_state_test.dart
@@ -8,8 +8,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
-@AngularEntrypoint()
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'component_state_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   tearDown(() => disposeAnyRunningTest());
 
   group('ComponentState mixin', () {

--- a/test/core/debug/debug_node_test.dart
+++ b/test/core/debug/debug_node_test.dart
@@ -10,7 +10,13 @@ import 'package:angular_test/angular_test.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'debug_node_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('debug element', () {
     tearDown(() => disposeAnyRunningTest());
 

--- a/test/core/directive_lifecycle_integration_test.dart
+++ b/test/core/directive_lifecycle_integration_test.dart
@@ -6,7 +6,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'directive_lifecycle_integration_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group("directive lifecycle integration spec", () {
     Log log;
     var fixture;

--- a/test/core/linker/component_selector_test.dart
+++ b/test/core/linker/component_selector_test.dart
@@ -8,7 +8,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'component_selector_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('Selector', () {
     tearDown(() => disposeAnyRunningTest());
     test('should support attaching component to tr tag', () async {

--- a/test/core/linker/error_integration_test.dart
+++ b/test/core/linker/error_integration_test.dart
@@ -10,7 +10,13 @@ import 'package:angular2/src/facade/exceptions.dart' show BaseException;
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'error_integration_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('Error handling', () {
     tearDown(() => disposeAnyRunningTest());
     test('should preserve Error stack traces thrown from components', () async {

--- a/test/core/linker/host_attributes_test.dart
+++ b/test/core/linker/host_attributes_test.dart
@@ -8,7 +8,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'host_attributes_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('Host attributes', () {
     tearDown(() => disposeAnyRunningTest());
     test('On component itself should be rendered', () async {

--- a/test/core/linker/host_events_test.dart
+++ b/test/core/linker/host_events_test.dart
@@ -8,7 +8,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'host_events_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('Events', () {
     tearDown(() => disposeAnyRunningTest());
     test('defined inside component itself should add listeners', () async {

--- a/test/core/linker/integration_dart_test.dart
+++ b/test/core/linker/integration_dart_test.dart
@@ -11,7 +11,13 @@ import 'package:angular_test/angular_test.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'integration_dart_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('Property access', () {
     test('should distinguish between map and property access', () async {
       var testBed = new NgTestBed<ContainerWithPropertyAccess>();

--- a/test/core/styling/shim_test.dart
+++ b/test/core/styling/shim_test.dart
@@ -8,7 +8,13 @@ import 'package:angular2/angular2.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'shim_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('host styling', () {
     tearDown(disposeAnyRunningTest);
 

--- a/test/core/view/projection_test.dart
+++ b/test/core/view/projection_test.dart
@@ -10,7 +10,13 @@ import 'package:angular2/src/testing/matchers.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'projection_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   group('projection', () {
     tearDown(() => disposeAnyRunningTest());
 

--- a/test/security/safe_inner_html_test.dart
+++ b/test/security/safe_inner_html_test.dart
@@ -7,8 +7,13 @@ import 'package:angular2/security.dart';
 import 'package:angular_test/angular_test.dart';
 import 'package:test/test.dart';
 
-@AngularEntrypoint()
+// Not common practice, just to avoid a circular pub transformer dependency.
+// ignore: uri_has_not_been_generated
+import 'safe_inner_html_test.template.dart' as ng_codegen;
+
 void main() {
+  ng_codegen.initReflector();
+
   tearDown(() => disposeAnyRunningTest());
 
   group('$SafeInnerHtmlDirective', () {

--- a/tool/run_codegen_tests.sh
+++ b/tool/run_codegen_tests.sh
@@ -16,8 +16,7 @@ exec 3< <(pub serve test --port $PUB_PORT)
 sed '/Build completed/q' <&3 ; cat <&3 &
 
 # Run the codegen tests only.
-pub run test --pub-serve=$PUB_PORT -t codegen -p content-shell \
-    test/security \
+pub run test --pub-serve=$PUB_PORT -t codegen -p content-shell
 
 # Kill pub since we succeeded.
 pid=$(lsof -i:$PUB_PORT -t); kill -TERM $pid || kill -KILL $pid

--- a/tool/run_codegen_tests.sh
+++ b/tool/run_codegen_tests.sh
@@ -16,7 +16,7 @@ exec 3< <(pub serve test --port $PUB_PORT)
 sed '/Build completed/q' <&3 ; cat <&3 &
 
 # Run the codegen tests only.
-pub run test --pub-serve=$PUB_PORT -t codegen -p content-shell
+pub run test -t codegen -p content-shell --pub-serve=$PUB_PORT
 
 # Kill pub since we succeeded.
 pid=$(lsof -i:$PUB_PORT -t); kill -TERM $pid || kill -KILL $pid

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -30,9 +30,7 @@ echo $THE_COMMAND
 $THE_COMMAND
 
 if [ $TEST_PLATFORM == 'content-shell' ]; then
-  echo "** SKIPPING pub tests – with codegen - broken!"
-  echo "** See https://github.com/dart-lang/angular2/issues/272"
-  # "$(dirname "$0")/run_codegen_tests.sh"
+  "$(dirname "$0")/run_codegen_tests.sh"
 fi
 
 echo "** Done!!"


### PR DESCRIPTION
By removing `reflection_remover` (???) and doing the steps manually instead.

(/cc @natebosch)

Closes https://github.com/dart-lang/angular2/issues/272