### PR TITLE
API doc: ApplicationRef.bootstrap, remove TS ex. ref

### DIFF
--- a/lib/src/core/application_ref.dart
+++ b/lib/src/core/application_ref.dart
@@ -189,18 +189,10 @@ abstract class ApplicationRef {
 
   /// Bootstrap a new component at the root level of the application.
   ///
-  /// ### Bootstrap process
-  ///
-  /// When bootstrapping a new root component into an application, Angular mounts the
-  /// specified application component onto DOM elements identified by the [componentType]'s
-  /// selector and kicks off automatic change detection to finish initializing the component.
-  ///
-  /// ### Example
-  ///
-  /// ```dart
-  /// // {@disabled-source "core/ts/platform/platform.ts" region="longform"}
-  /// ```
-  ///
+  /// When bootstrapping a new root component into an application,
+  /// Angular mounts the specified application component onto DOM elements
+  /// identified by the [ComponentFactory.componentType]'s selector and kicks
+  /// off automatic change detection to finish initializing the component.
   ComponentRef bootstrap(ComponentFactory componentFactory);
 
   /// Retrieve the application [Injector].


### PR DESCRIPTION
Remove reference to TS example. This is the last `{@disabled-source}` entry in the API docs.

Not sure that this usage is common enough. If so, we can always add a Dart example

cc @kwalrath 