### PR TITLE
Cheatsheet updates: SwitchCase, EventEmitter

### DIFF
--- a/doc/cheatsheet/built-in-directives.md
+++ b/doc/cheatsheet/built-in-directives.md
@@ -27,16 +27,16 @@ See: [Template Syntax](/angular/guide/template-syntax),
 @cheatsheetItem
 syntax:
 `<div [ngSwitch]="conditionExpression">
-  <template [ngSwitchWhen]="case1Exp">...</template>
-  <template ngSwitchWhen="case2LiteralString">...</template>
+  <template [ngSwitchCase]="case1Exp">...</template>
+  <template ngSwitchCase="case2LiteralString">...</template>
   <template ngSwitchDefault>...</template>
-</div>`|`[ngSwitch]`|`[ngSwitchWhen]`|`ngSwitchWhen`|`ngSwitchDefault`
+</div>`|`[ngSwitch]`|`[ngSwitchCase]`|`ngSwitchCase`|`ngSwitchDefault`
 description:
 Conditionally swaps the contents of the div by selecting one of the embedded templates based on the current value of conditionExpression.
 
 See: [Template Syntax](/angular/guide/template-syntax),
 [NgSwitch class](/angular/api/angular2.common/NgSwitch-class),
-[NgSwitchWhen class](/angular/api/angular2.common/NgSwitchWhen-class),
+[NgSwitchCase class](/angular/api/angular2.common/NgSwitchWhen-class),
 [NgSwitchDefault class](/angular/api/angular2.common/NgSwitchDefault-class)
 
 @cheatsheetItem

--- a/doc/cheatsheet/directive-and-component-decorators.md
+++ b/doc/cheatsheet/directive-and-component-decorators.md
@@ -17,7 +17,8 @@ See: [Template Syntax](/angular/guide/template-syntax),
 
 @cheatsheetItem
 syntax:
-`@Output() myEvent = new EventEmitter();`|`@Output()`
+`final _myEvent = new StreamController<T>();
+!@Output() Stream<T> get myEvent => _myEvent.stream;`|`@Output()`
 description:
 Declares an output property that fires events that you can subscribe to with an event binding (example: `<my-cmp (myEvent)="doSomething()">`).
 
@@ -36,7 +37,8 @@ See: [HostBinding class](/angular/api/angular2.core/HostBinding-class)
 
 @cheatsheetItem
 syntax:
-`@HostListener('click', ['$event']) onClick(e) {...}`|`@HostListener('click', ['$event'])`
+`@HostListener('click', ['$event'])
+onClick(e) {...}`|`@HostListener('click', ['$event'])`
 description:
 Subscribes to a host element event (`click`) with a directive/component method (`onClick`), optionally passing an argument (`$event`).
 


### PR DESCRIPTION
- Dropped `EventEmitter`
- `ngSwitchWhen` --> `ngSwitchCase`

cc @kwalrath 