### PR TITLE
Replace custom @source directive by std processing instruction

### DIFF
--- a/lib/platform/browser.dart
+++ b/lib/platform/browser.dart
@@ -105,8 +105,8 @@ PlatformRef browserPlatform() {
 ///
 /// ### Examples
 ///
+/// <?code-excerpt "docs/quickstart/web/main.dart"?>
 /// ```dart
-/// // {@source "docs/quickstart/web/main.dart"}
 /// import 'package:angular2/platform/browser.dart';
 ///
 /// import 'package:angular_quickstart/app_component.dart';
@@ -116,8 +116,8 @@ PlatformRef browserPlatform() {
 /// }
 /// ```
 ///
+/// <?code-excerpt "docs/toh-6/web/main.dart"?>
 /// ```dart
-/// // {@source "docs/toh-6/web/main.dart"}
 /// import 'package:angular2/core.dart';
 /// import 'package:angular2/platform/browser.dart';
 /// import 'package:angular_tour_of_heroes/app_component.dart';

--- a/lib/src/common/directives/ng_class.dart
+++ b/lib/src/common/directives/ng_class.dart
@@ -23,13 +23,13 @@ import 'package:angular2/src/core/change_detection/differs/default_keyvalue_diff
 ///
 /// ### Examples
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgClass-1"?>
 /// ```html
-/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgClass-1"} -->
 /// <div [ngClass]="currentClasses">This div is initially saveable, unchanged, and special</div>
 /// ```
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.dart" region="setClasses"?>
 /// ```dart
-/// // {@source "docs/template-syntax/lib/app_component.dart" region="setClasses"}
 /// Map<String, bool> currentClasses = <String, bool>{};
 /// void setCurrentClasses() {
 ///   currentClasses = <String, bool>{

--- a/lib/src/common/directives/ng_class.dart
+++ b/lib/src/common/directives/ng_class.dart
@@ -23,12 +23,12 @@ import 'package:angular2/src/core/change_detection/differs/default_keyvalue_diff
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgClass-1"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgClass-1)"?>
 /// ```html
 /// <div [ngClass]="currentClasses">This div is initially saveable, unchanged, and special</div>
 /// ```
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.dart" region="setClasses"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.dart (setClasses)"?>
 /// ```dart
 /// Map<String, bool> currentClasses = <String, bool>{};
 /// void setCurrentClasses() {

--- a/lib/src/common/directives/ng_for.dart
+++ b/lib/src/common/directives/ng_for.dart
@@ -61,18 +61,18 @@ import '../../core/change_detection/differs/default_iterable_differ.dart'
 ///
 /// ### Examples
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgFor-1"?>
 /// ```html
-/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgFor-1"} -->
 /// <div *ngFor="let hero of heroes">{{hero.name}}</div>
 /// ```
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgFor-2"?>
 /// ```html
-/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgFor-2"} -->
 /// <hero-detail *ngFor="let hero of heroes" [hero]="hero"></hero-detail>
 /// ```
 ///
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="inside-ngfor"?>
 /// ```html
-/// <!-- {@source "docs/structural-directives/lib/app_component.html" region="inside-ngfor"} -->
 /// <div *ngFor="let hero of heroes; let i=index; let odd=odd; trackBy: trackById"
 ///      [class.odd]="odd">
 ///   ({{i}}) {{hero.name}}

--- a/lib/src/common/directives/ng_for.dart
+++ b/lib/src/common/directives/ng_for.dart
@@ -61,17 +61,17 @@ import '../../core/change_detection/differs/default_iterable_differ.dart'
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgFor-1"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgFor-1)"?>
 /// ```html
 /// <div *ngFor="let hero of heroes">{{hero.name}}</div>
 /// ```
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgFor-2"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgFor-2)"?>
 /// ```html
 /// <hero-detail *ngFor="let hero of heroes" [hero]="hero"></hero-detail>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="inside-ngfor"?>
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html (inside-ngfor)"?>
 /// ```html
 /// <div *ngFor="let hero of heroes; let i=index; let odd=odd; trackBy: trackById"
 ///      [class.odd]="odd">

--- a/lib/src/common/directives/ng_if.dart
+++ b/lib/src/common/directives/ng_if.dart
@@ -8,23 +8,23 @@ import 'package:angular2/core.dart'
 ///
 /// ### Examples
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgIf-1"?>
 /// ```html
-/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgIf-1"} -->
 /// <hero-detail *ngIf="isActive"></hero-detail>
 /// ```
 ///
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="asterisk"?>
 /// ```html
-/// <!-- {@source "docs/structural-directives/lib/app_component.html" region="asterisk"} -->
 /// <div *ngIf="hero != null" >{{hero.name}}</div>
 /// ```
 ///
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngif-template-attr"?>
 /// ```html
-/// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngif-template-attr"} -->
 /// <div template="ngIf hero != null">{{hero.name}}</div>
 /// ```
 ///
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngif-template"?>
 /// ```html
-/// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngif-template"} -->
 /// <template [ngIf]="hero != null">
 ///   <div>{{hero.name}}</div>
 /// </template>

--- a/lib/src/common/directives/ng_if.dart
+++ b/lib/src/common/directives/ng_if.dart
@@ -8,22 +8,22 @@ import 'package:angular2/core.dart'
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgIf-1"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgIf-1)"?>
 /// ```html
 /// <hero-detail *ngIf="isActive"></hero-detail>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="asterisk"?>
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html (asterisk)"?>
 /// ```html
 /// <div *ngIf="hero != null" >{{hero.name}}</div>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngif-template-attr"?>
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html (ngif-template-attr)"?>
 /// ```html
 /// <div template="ngIf hero != null">{{hero.name}}</div>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngif-template"?>
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html (ngif-template)"?>
 /// ```html
 /// <template [ngIf]="hero != null">
 ///   <div>{{hero.name}}</div>

--- a/lib/src/common/directives/ng_style.dart
+++ b/lib/src/common/directives/ng_style.dart
@@ -23,14 +23,14 @@ import '../../core/change_detection/differs/default_keyvalue_differ.dart'
 /// the relevant excerpts from the example's template and the corresponding
 /// component class:
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgStyle-2"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgStyle-2)"?>
 /// ```html
 /// <div [ngStyle]="currentStyles">
 ///   This div is initially italic, normal weight, and extra large (24px).
 /// </div>
 /// ```
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.dart" region="setStyles"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.dart (setStyles)"?>
 /// ```dart
 /// Map<String, String> currentStyles = <String, String>{};
 /// void setCurrentStyles() {

--- a/lib/src/common/directives/ng_style.dart
+++ b/lib/src/common/directives/ng_style.dart
@@ -23,15 +23,15 @@ import '../../core/change_detection/differs/default_keyvalue_differ.dart'
 /// the relevant excerpts from the example's template and the corresponding
 /// component class:
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgStyle-2"?>
 /// ```html
-/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgStyle-2"} -->
 /// <div [ngStyle]="currentStyles">
 ///   This div is initially italic, normal weight, and extra large (24px).
 /// </div>
 /// ```
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.dart" region="setStyles"?>
 /// ```dart
-/// // {@source "docs/template-syntax/lib/app_component.dart" region="setStyles"}
 /// Map<String, String> currentStyles = <String, String>{};
 /// void setCurrentStyles() {
 ///   currentStyles = <String, String>{

--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -39,7 +39,7 @@ class SwitchView {
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngswitch"?>
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html (ngswitch)"?>
 /// ```html
 /// <div [ngSwitch]="hero?.emotion">
 ///   <happy-hero    *ngSwitchCase="'happy'"    [hero]="hero"></happy-hero>
@@ -49,7 +49,7 @@ class SwitchView {
 /// </div>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngswitch-template-attr"?>
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html (ngswitch-template-attr)"?>
 /// ```html
 /// <div [ngSwitch]="hero?.emotion">
 ///   <happy-hero    template="ngSwitchCase 'happy'"    [hero]="hero"></happy-hero>
@@ -59,7 +59,7 @@ class SwitchView {
 /// </div>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngswitch-template"?>
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html (ngswitch-template)"?>
 /// ```html
 /// <div [ngSwitch]="hero?.emotion">
 ///   <template [ngSwitchCase]="'happy'">

--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -42,9 +42,9 @@ class SwitchView {
 /// ```html
 /// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngswitch"} -->
 /// <div [ngSwitch]="hero?.emotion">
-///   <happy-hero    *ngSwitchWhen="'happy'"    [hero]="hero"></happy-hero>
-///   <sad-hero      *ngSwitchWhen="'sad'"      [hero]="hero"></sad-hero>
-///   <confused-hero *ngSwitchWhen="'confused'" [hero]="hero"></confused-hero>
+///   <happy-hero    *ngSwitchCase="'happy'"    [hero]="hero"></happy-hero>
+///   <sad-hero      *ngSwitchCase="'sad'"      [hero]="hero"></sad-hero>
+///   <confused-hero *ngSwitchCase="'confused'" [hero]="hero"></confused-hero>
 ///   <unknown-hero  *ngSwitchDefault           [hero]="hero"></unknown-hero>
 /// </div>
 /// ```
@@ -52,9 +52,9 @@ class SwitchView {
 /// ```html
 /// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngswitch-template-attr"} -->
 /// <div [ngSwitch]="hero?.emotion">
-///   <happy-hero    template="ngSwitchWhen 'happy'"    [hero]="hero"></happy-hero>
-///   <sad-hero      template="ngSwitchWhen 'sad'"      [hero]="hero"></sad-hero>
-///   <confused-hero template="ngSwitchWhen 'confused'" [hero]="hero"></confused-hero>
+///   <happy-hero    template="ngSwitchCase 'happy'"    [hero]="hero"></happy-hero>
+///   <sad-hero      template="ngSwitchCase 'sad'"      [hero]="hero"></sad-hero>
+///   <confused-hero template="ngSwitchCase 'confused'" [hero]="hero"></confused-hero>
 ///   <unknown-hero  template="ngSwitchDefault"         [hero]="hero"></unknown-hero>
 /// </div>
 /// ```
@@ -62,13 +62,13 @@ class SwitchView {
 /// ```html
 /// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngswitch-template"} -->
 /// <div [ngSwitch]="hero?.emotion">
-///   <template [ngSwitchWhen]="'happy'">
+///   <template [ngSwitchCase]="'happy'">
 ///     <happy-hero [hero]="hero"></happy-hero>
 ///   </template>
-///   <template [ngSwitchWhen]="'sad'">
+///   <template [ngSwitchCase]="'sad'">
 ///     <sad-hero [hero]="hero"></sad-hero>
 ///   </template>
-///   <template [ngSwitchWhen]="'confused'">
+///   <template [ngSwitchCase]="'confused'">
 ///     <confused-hero [hero]="hero"></confused-hero>
 ///   </template >
 ///   <template ngSwitchDefault>

--- a/lib/src/common/directives/ng_switch.dart
+++ b/lib/src/common/directives/ng_switch.dart
@@ -39,8 +39,8 @@ class SwitchView {
 ///
 /// ### Examples
 ///
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngswitch"?>
 /// ```html
-/// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngswitch"} -->
 /// <div [ngSwitch]="hero?.emotion">
 ///   <happy-hero    *ngSwitchCase="'happy'"    [hero]="hero"></happy-hero>
 ///   <sad-hero      *ngSwitchCase="'sad'"      [hero]="hero"></sad-hero>
@@ -49,8 +49,8 @@ class SwitchView {
 /// </div>
 /// ```
 ///
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngswitch-template-attr"?>
 /// ```html
-/// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngswitch-template-attr"} -->
 /// <div [ngSwitch]="hero?.emotion">
 ///   <happy-hero    template="ngSwitchCase 'happy'"    [hero]="hero"></happy-hero>
 ///   <sad-hero      template="ngSwitchCase 'sad'"      [hero]="hero"></sad-hero>
@@ -59,8 +59,8 @@ class SwitchView {
 /// </div>
 /// ```
 ///
+/// <?code-excerpt "docs/structural-directives/lib/app_component.html" region="ngswitch-template"?>
 /// ```html
-/// <!-- {@source "docs/structural-directives/lib/app_component.html" region="ngswitch-template"} -->
 /// <div [ngSwitch]="hero?.emotion">
 ///   <template [ngSwitchCase]="'happy'">
 ///     <happy-hero [hero]="hero"></happy-hero>

--- a/lib/src/common/forms/directives/ng_model.dart
+++ b/lib/src/common/forms/directives/ng_model.dart
@@ -35,14 +35,14 @@ const formControlBinding = const Provider(NgControl, useExisting: NgModel);
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgModel-1"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgModel-1)"?>
 /// ```html
 /// <input [(ngModel)]="currentHero.name">
 /// ```
 ///
 /// This is equivalent to having separate bindings:
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgModel-3"?>
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgModel-3)"?>
 /// ```html
 /// <input
 ///   [ngModel]="currentHero.name"

--- a/lib/src/common/forms/directives/ng_model.dart
+++ b/lib/src/common/forms/directives/ng_model.dart
@@ -35,15 +35,15 @@ const formControlBinding = const Provider(NgControl, useExisting: NgModel);
 ///
 /// ### Examples
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgModel-1"?>
 /// ```html
-/// <!-- {@source "docs/template-syntax/lib/app_component.html" region="NgModel-1"} -->
 /// <input [(ngModel)]="currentHero.name">
 /// ```
 ///
 /// This is equivalent to having separate bindings:
 ///
+/// <?code-excerpt "docs/template-syntax/lib/app_component.html" region="NgModel-3"?>
 /// ```html
-/// {@source "docs/template-syntax/lib/app_component.html" region="NgModel-3"}
 /// <input
 ///   [ngModel]="currentHero.name"
 ///   (ngModelChange)="currentHero.name=$event">

--- a/lib/src/common/pipes/async_pipe.dart
+++ b/lib/src/common/pipes/async_pipe.dart
@@ -39,7 +39,7 @@ final _observableStrategy = new ObservableStrategy();
 ///
 /// ### Example
 ///
-/// <?code-excerpt "common/pipes/lib/async_pipe.dart" region="AsyncPipe"?>
+/// <?code-excerpt "common/pipes/lib/async_pipe.dart (AsyncPipe)"?>
 /// ```dart
 /// @Component(
 ///     selector: 'async-greeter',

--- a/lib/src/common/pipes/async_pipe.dart
+++ b/lib/src/common/pipes/async_pipe.dart
@@ -39,8 +39,8 @@ final _observableStrategy = new ObservableStrategy();
 ///
 /// ### Example
 ///
+/// <?code-excerpt "common/pipes/lib/async_pipe.dart" region="AsyncPipe"?>
 /// ```dart
-/// // {@source "common/pipes/lib/async_pipe.dart" region="AsyncPipe"}
 /// @Component(
 ///     selector: 'async-greeter',
 ///     template: '''

--- a/lib/src/common/pipes/slice_pipe.dart
+++ b/lib/src/common/pipes/slice_pipe.dart
@@ -34,8 +34,8 @@ import 'invalid_pipe_argument_exception.dart' show InvalidPipeArgumentException;
 ///
 /// ### Examples
 ///
+/// <?code-excerpt "common/pipes/lib/app_component.html" region="slice"?>
 /// ```html
-/// <!-- {@source "common/pipes/lib/app_component.html" region="slice"} -->
 /// <ul>
 ///     <li *ngFor="let i of ['a', 'b', 'c', 'd'] | slice:1:3">{{i}}</li>
 /// </ul>

--- a/lib/src/common/pipes/slice_pipe.dart
+++ b/lib/src/common/pipes/slice_pipe.dart
@@ -34,7 +34,7 @@ import 'invalid_pipe_argument_exception.dart' show InvalidPipeArgumentException;
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "common/pipes/lib/app_component.html" region="slice"?>
+/// <?code-excerpt "common/pipes/lib/app_component.html (slice)"?>
 /// ```html
 /// <ul>
 ///     <li *ngFor="let i of ['a', 'b', 'c', 'd'] | slice:1:3">{{i}}</li>

--- a/lib/src/core/di/provider.dart
+++ b/lib/src/core/di/provider.dart
@@ -164,8 +164,8 @@ class Provider {
 ///
 /// ### Example
 ///
+/// <?code-excerpt "docs/toh-6/web/main.dart"?>
 /// ```dart
-/// // {@source "docs/toh-6/web/main.dart"}
 /// import 'package:angular2/core.dart';
 /// import 'package:angular2/platform/browser.dart';
 /// import 'package:angular_tour_of_heroes/app_component.dart';

--- a/lib/src/core/metadata.dart
+++ b/lib/src/core/metadata.dart
@@ -20,8 +20,8 @@ export 'metadata/view.dart';
 /// An annotation that marks a class as an Angular directive, allowing you to
 /// attach behavior to elements in the DOM.
 ///
+/// <?code-excerpt "docs/attribute-directives/lib/highlight_directive_1.dart"?>
 /// ```dart
-/// // {@source "docs/attribute-directives/lib/highlight_directive_1.dart"}
 /// import 'package:angular2/core.dart';
 ///
 /// @Directive(selector: '[myHighlight]')

--- a/lib/src/core/metadata/lifecycle_hooks.dart
+++ b/lib/src/core/metadata/lifecycle_hooks.dart
@@ -47,7 +47,7 @@ var LIFECYCLE_HOOKS_VALUES = [
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/on_changes_component.dart" region="ng-on-changes"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/on_changes_component.dart (ng-on-changes)"?>
 /// ```dart
 /// ngOnChanges(Map<String, SimpleChange> changes) {
 ///   changes.forEach((String propName, SimpleChange change) {
@@ -76,7 +76,7 @@ abstract class OnChanges {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/spy_directive.dart (spy-directive)"?>
 /// ```dart
 /// // Spy on any element to which it is applied.
 /// // Usage: <div mySpy>...</div>
@@ -126,7 +126,7 @@ abstract class OnInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/do_check_component.dart" region="ng-do-check"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/do_check_component.dart (ng-do-check)"?>
 /// ```dart
 /// ngDoCheck() {
 ///   if (hero.name != oldHeroName) {
@@ -177,7 +177,7 @@ abstract class DoCheck {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/spy_directive.dart (spy-directive)"?>
 /// ```dart
 /// // Spy on any element to which it is applied.
 /// // Usage: <div mySpy>...</div>
@@ -208,7 +208,7 @@ abstract class OnDestroy {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart (template)"?>
 /// ```dart
 /// template: '''
 ///   <div>-- projected content begins --</div>
@@ -218,7 +218,7 @@ abstract class OnDestroy {
 /// '''
 /// ```
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart (hooks)"?>
 /// ```dart
 /// class AfterContentComponent implements AfterContentChecked, AfterContentInit {
 ///   String _prevHero = '';
@@ -260,7 +260,7 @@ abstract class AfterContentInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart (template)"?>
 /// ```dart
 /// template: '''
 ///   <div>-- projected content begins --</div>
@@ -270,7 +270,7 @@ abstract class AfterContentInit {
 /// '''
 /// ```
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart (hooks)"?>
 /// ```dart
 /// class AfterContentComponent implements AfterContentChecked, AfterContentInit {
 ///   String _prevHero = '';
@@ -312,7 +312,7 @@ abstract class AfterContentChecked {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart (template)"?>
 /// ```dart
 /// template: '''
 ///   <div>-- child view begins --</div>
@@ -321,7 +321,7 @@ abstract class AfterContentChecked {
 ///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>''',
 /// ```
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart (hooks)"?>
 /// ```dart
 /// class AfterViewComponent implements AfterViewChecked, AfterViewInit {
 ///   var _prevHero = '';
@@ -362,7 +362,7 @@ abstract class AfterViewInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart (template)"?>
 /// ```dart
 /// template: '''
 ///   <div>-- child view begins --</div>
@@ -371,7 +371,7 @@ abstract class AfterViewInit {
 ///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>''',
 /// ```
 ///
-/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"?>
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart (hooks)"?>
 /// ```dart
 /// class AfterViewComponent implements AfterViewChecked, AfterViewInit {
 ///   var _prevHero = '';

--- a/lib/src/core/metadata/lifecycle_hooks.dart
+++ b/lib/src/core/metadata/lifecycle_hooks.dart
@@ -47,8 +47,8 @@ var LIFECYCLE_HOOKS_VALUES = [
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/on_changes_component.dart" region="ng-on-changes"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/on_changes_component.dart" region="ng-on-changes"}
 /// ngOnChanges(Map<String, SimpleChange> changes) {
 ///   changes.forEach((String propName, SimpleChange change) {
 ///     String cur = JSON.encode(change.currentValue);
@@ -76,8 +76,8 @@ abstract class OnChanges {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"}
 /// // Spy on any element to which it is applied.
 /// // Usage: <div mySpy>...</div>
 /// @Directive(selector: '[mySpy]')
@@ -126,8 +126,8 @@ abstract class OnInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/do_check_component.dart" region="ng-do-check"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/do_check_component.dart" region="ng-do-check"}
 /// ngDoCheck() {
 ///   if (hero.name != oldHeroName) {
 ///     changeDetected = true;
@@ -177,8 +177,8 @@ abstract class DoCheck {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/spy_directive.dart" region="spy-directive"}
 /// // Spy on any element to which it is applied.
 /// // Usage: <div mySpy>...</div>
 /// @Directive(selector: '[mySpy]')
@@ -208,8 +208,8 @@ abstract class OnDestroy {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"}
 /// template: '''
 ///   <div>-- projected content begins --</div>
 ///     <ng-content></ng-content>
@@ -218,8 +218,8 @@ abstract class OnDestroy {
 /// '''
 /// ```
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"}
 /// class AfterContentComponent implements AfterContentChecked, AfterContentInit {
 ///   String _prevHero = '';
 ///   String comment = '';
@@ -260,8 +260,8 @@ abstract class AfterContentInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="template"}
 /// template: '''
 ///   <div>-- projected content begins --</div>
 ///     <ng-content></ng-content>
@@ -270,8 +270,8 @@ abstract class AfterContentInit {
 /// '''
 /// ```
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_content_component.dart" region="hooks"}
 /// class AfterContentComponent implements AfterContentChecked, AfterContentInit {
 ///   String _prevHero = '';
 ///   String comment = '';
@@ -312,8 +312,8 @@ abstract class AfterContentChecked {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"}
 /// template: '''
 ///   <div>-- child view begins --</div>
 ///     <my-child-view></my-child-view>
@@ -321,8 +321,8 @@ abstract class AfterContentChecked {
 ///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>''',
 /// ```
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"}
 /// class AfterViewComponent implements AfterViewChecked, AfterViewInit {
 ///   var _prevHero = '';
 ///
@@ -362,8 +362,8 @@ abstract class AfterViewInit {
 ///
 /// Try this [live example][ex] from the [Lifecycle Hooks][docs] page:
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="template"}
 /// template: '''
 ///   <div>-- child view begins --</div>
 ///     <my-child-view></my-child-view>
@@ -371,8 +371,8 @@ abstract class AfterViewInit {
 ///   <p *ngIf="comment.isNotEmpty" class="comment">{{comment}}</p>''',
 /// ```
 ///
+/// <?code-excerpt "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"?>
 /// ```dart
-/// // {@source "docs/lifecycle-hooks/lib/after_view_component.dart" region="hooks"}
 /// class AfterViewComponent implements AfterViewChecked, AfterViewInit {
 ///   var _prevHero = '';
 ///

--- a/lib/src/core/zone/ng_zone.dart
+++ b/lib/src/core/zone/ng_zone.dart
@@ -17,8 +17,8 @@ import 'package:stack_trace/stack_trace.dart';
 ///
 /// ## Example
 ///
+/// <?code-excerpt "core/ngzone/lib/app_component.dart"?>
 /// ```dart
-/// // {@source "core/ngzone/lib/app_component.dart"}
 /// import 'dart:async';
 ///
 /// import 'package:angular2/core.dart';

--- a/lib/src/router/directives/router_link.dart
+++ b/lib/src/router/directives/router_link.dart
@@ -8,8 +8,8 @@ import "../router.dart" show Router;
 ///
 /// Consider the following route configuration:
 ///
+/// <?code-excerpt "docs/toh-5/lib/app_component.dart" region="heroes"?>
 /// ```dart
-/// // {@source "docs/toh-5/lib/app_component.dart" region="heroes"}
 /// @RouteConfig(const [
 ///   const Route(path: '/heroes', name: 'Heroes', component: HeroesComponent)
 /// ])
@@ -17,8 +17,8 @@ import "../router.dart" show Router;
 ///
 /// When linking to this `Heroes` route, you can write:
 ///
+/// <?code-excerpt "docs/toh-5/lib/app_component_1.dart" region="template-v2"?>
 /// ```dart
-/// // {@source "docs/toh-5/lib/app_component_1.dart" region="template-v2"}
 /// template: '''
 ///   <h1>{{title}}</h1>
 ///   <a [routerLink]="['Heroes']">Heroes</a>

--- a/lib/src/router/directives/router_link.dart
+++ b/lib/src/router/directives/router_link.dart
@@ -8,7 +8,7 @@ import "../router.dart" show Router;
 ///
 /// Consider the following route configuration:
 ///
-/// <?code-excerpt "docs/toh-5/lib/app_component.dart" region="heroes"?>
+/// <?code-excerpt "docs/toh-5/lib/app_component.dart (heroes)"?>
 /// ```dart
 /// @RouteConfig(const [
 ///   const Route(path: '/heroes', name: 'Heroes', component: HeroesComponent)
@@ -17,7 +17,7 @@ import "../router.dart" show Router;
 ///
 /// When linking to this `Heroes` route, you can write:
 ///
-/// <?code-excerpt "docs/toh-5/lib/app_component_1.dart" region="template-v2"?>
+/// <?code-excerpt "docs/toh-5/lib/app_component_1.dart (template-v2)"?>
 /// ```dart
 /// template: '''
 ///   <h1>{{title}}</h1>

--- a/lib/src/router/directives/router_outlet.dart
+++ b/lib/src/router/directives/router_outlet.dart
@@ -29,8 +29,8 @@ var _resolveToTrue = new Future<bool>.value(true);
 ///
 /// Here is an example from the [tutorial on routing][routing]:
 ///
+/// <?code-excerpt "docs/toh-5/lib/app_component.dart" region="template"?>
 /// ```dart
-/// // {@source "docs/toh-5/lib/app_component.dart" region="template"}
 /// template: '''
 ///   <h1>{{title}}</h1>
 ///   <nav>

--- a/lib/src/router/directives/router_outlet.dart
+++ b/lib/src/router/directives/router_outlet.dart
@@ -29,7 +29,7 @@ var _resolveToTrue = new Future<bool>.value(true);
 ///
 /// Here is an example from the [tutorial on routing][routing]:
 ///
-/// <?code-excerpt "docs/toh-5/lib/app_component.dart" region="template"?>
+/// <?code-excerpt "docs/toh-5/lib/app_component.dart (template)"?>
 /// ```dart
 /// template: '''
 ///   <h1>{{title}}</h1>

--- a/lib/src/router/interfaces.dart
+++ b/lib/src/router/interfaces.dart
@@ -15,8 +15,9 @@ import 'instruction.dart' show ComponentInstruction;
 /// instantiate and activate child components.
 ///
 /// ### Example
+///
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnActivate"?>
 /// ```dart
-/// // {@source "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnActivate"}
 /// @override
 /// void routerOnActivate(next, prev) {
 ///   print('Activating ${next.routeName} ${next.urlPath}');
@@ -44,8 +45,8 @@ abstract class OnActivate {
 ///
 /// ### Example
 ///
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnReuse"?>
 /// ```dart
-/// // {@source "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnReuse"}
 /// @override
 /// Future<Null> routerOnReuse(ComponentInstruction next, prev) =>
 ///     _setCrisis(next.params['id']);
@@ -72,8 +73,8 @@ abstract class OnReuse {
 ///
 /// ### Example
 ///
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnDeactivate"?>
 /// ```dart
-/// // {@source "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnDeactivate"}
 /// @override
 /// void routerOnDeactivate(next, prev) {
 ///   print('Deactivating ${prev.routeName} ${prev.urlPath}');
@@ -106,8 +107,8 @@ abstract class OnDeactivate {
 ///
 /// ### Example
 ///
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerCanReuse"?>
 /// ```dart
-/// // {@source "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerCanReuse"}
 /// @override
 /// FutureOr<bool> routerCanReuse(next, prev) => true;
 /// ```
@@ -139,8 +140,8 @@ abstract class CanReuse {
 ///
 /// ### Example
 ///
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerCanDeactivate"?>
 /// ```dart
-/// // {@source "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerCanDeactivate"}
 /// @override
 /// FutureOr<bool> routerCanDeactivate(next, prev) =>
 ///     crisis == null || crisis.name == name

--- a/lib/src/router/interfaces.dart
+++ b/lib/src/router/interfaces.dart
@@ -16,7 +16,7 @@ import 'instruction.dart' show ComponentInstruction;
 ///
 /// ### Example
 ///
-/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnActivate"?>
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart (routerOnActivate)"?>
 /// ```dart
 /// @override
 /// void routerOnActivate(next, prev) {
@@ -45,7 +45,7 @@ abstract class OnActivate {
 ///
 /// ### Example
 ///
-/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnReuse"?>
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart (routerOnReuse)"?>
 /// ```dart
 /// @override
 /// Future<Null> routerOnReuse(ComponentInstruction next, prev) =>
@@ -73,7 +73,7 @@ abstract class OnReuse {
 ///
 /// ### Example
 ///
-/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerOnDeactivate"?>
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart (routerOnDeactivate)"?>
 /// ```dart
 /// @override
 /// void routerOnDeactivate(next, prev) {
@@ -107,7 +107,7 @@ abstract class OnDeactivate {
 ///
 /// ### Example
 ///
-/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerCanReuse"?>
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart (routerCanReuse)"?>
 /// ```dart
 /// @override
 /// FutureOr<bool> routerCanReuse(next, prev) => true;
@@ -140,7 +140,7 @@ abstract class CanReuse {
 ///
 /// ### Example
 ///
-/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart" region="routerCanDeactivate"?>
+/// <?code-excerpt "docs/router/lib/crisis_center/crisis_detail_component.dart (routerCanDeactivate)"?>
 /// ```dart
 /// @override
 /// FutureOr<bool> routerCanDeactivate(next, prev) =>

--- a/lib/src/router/route_config/route_config_decorator.dart
+++ b/lib/src/router/route_config/route_config_decorator.dart
@@ -11,8 +11,8 @@ export "../route_definition.dart" show RouteDefinition;
 ///
 /// Here is an example from the [tutorial on routing][routing]:
 ///
+/// <?code-excerpt "docs/toh-5/lib/app_component.dart" region="routes"?>
 /// ```dart
-/// // {@source "docs/toh-5/lib/app_component.dart" region="routes"}
 /// @RouteConfig(const [
 ///   const Route(
 ///       path: '/dashboard',

--- a/lib/src/router/route_config/route_config_decorator.dart
+++ b/lib/src/router/route_config/route_config_decorator.dart
@@ -11,7 +11,7 @@ export "../route_definition.dart" show RouteDefinition;
 ///
 /// Here is an example from the [tutorial on routing][routing]:
 ///
-/// <?code-excerpt "docs/toh-5/lib/app_component.dart" region="routes"?>
+/// <?code-excerpt "docs/toh-5/lib/app_component.dart (routes)"?>
 /// ```dart
 /// @RouteConfig(const [
 ///   const Route(


### PR DESCRIPTION
Replace all of the custom syntax `{@source ...}` with the standard [processing instruction](https://en.wikipedia.org/wiki/Processing_Instruction) (PI) syntax `<?code-excerpt ...?>`.  PI's are not rendered, so this fixes https://github.com/dart-lang/site-webdev/issues/551

Code excerpt updates are now handled by https://github.com/chalin/code_excerpt_updater.

This PR also updates the `ngSwitch` code excerpts.

cc @kwalrath 